### PR TITLE
updated test launcher and launcher itself

### DIFF
--- a/launcher_abler/AblerLauncher_test
+++ b/launcher_abler/AblerLauncher_test
@@ -16,21 +16,22 @@
 """
 
 import configparser
+import json
 import logging
 import os
 import os.path
 import platform
 import shutil
+import ssl
 import subprocess
 import sys
 import urllib.parse
 import urllib.request
+import webbrowser
 import time
+from datetime import datetime
 from distutils.dir_util import copy_tree
 from distutils.version import StrictVersion
-
-
-from win32com.client import Dispatch
 
 import requests
 
@@ -47,7 +48,7 @@ app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
 appversion = "1.9.8"
 dir_ = "C:/Program Files (x86)/ABLER"
-launcherdir_ = os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater"
+launcherdir_ = os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater"
 config = configparser.ConfigParser()
 btn = {}
 lastversion = ""
@@ -58,17 +59,11 @@ test_arg = False
 if len(sys.argv) > 1 and sys.argv[1] == '--test':
     test_arg = True
 
-if not os.path.isdir(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96"):
-    os.mkdir(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96")
-if not os.path.isdir(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater"):
-    os.mkdir(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater") 
 logging.basicConfig(
-    filename=os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\AblerLauncher.log", format=LOG_FORMAT, level=logging.DEBUG, filemode="w"
+    filename=os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.log", format=LOG_FORMAT, level=logging.DEBUG, filemode="w"
 )
 
 logger = logging.getLogger()
-
-
 
 
 class WorkerThread(QtCore.QThread):
@@ -136,18 +131,10 @@ class WorkerThread(QtCore.QThread):
             os.remove(self.filename)
             self.finishedEX.emit()
             source = next(os.walk(self.temp_path))
-            if "updater" in self.path:
-                if os.path.isfile(self.path + "\\AblerLauncher.exe"):
-                    os.rename(self.path + "\\AblerLauncher.exe", self.path + "\\AblerLauncher.bak")
+            if os.path.isfile(self.path + "\\AblerLauncher.exe"):
+                os.rename(self.path + "\\AblerLauncher.exe", self.path + "\\AblerLauncher.bak")
                 time.sleep(1)
                 shutil.copyfile(self.temp_path + "\\AblerLauncher.exe", self.path + "\\AblerLauncher.exe")
-                sym_path = os.getenv('APPDATA') + "\\Microsoft\\Windows\\Start Menu\\Programs\\ABLER\\Launch ABLER.lnk"
-                if os.path.isfile(sym_path):
-                    os.remove(sym_path)
-                shell = Dispatch('WScript.Shell')
-                shortcut = shell.CreateShortCut(sym_path)
-                shortcut.Targetpath = self.path + "\\AblerLauncher.exe"
-                shortcut.save()
                 # os.remove(self.path + "\\config.ini")
                 # shutil.copyfile(self.temp_path + "\\config.ini", self.path + "\\config.ini")
             else:
@@ -178,12 +165,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         global config
         global installedversion
         global launcher_installed
-        if os.path.isfile(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\AblerLauncher.bak"):
-            os.remove(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\AblerLauncher.bak")
-        if os.path.isfile(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini"):
+        if os.path.isfile(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.bak"):
+            os.remove(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.bak")
+        if os.path.isfile(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini"):
             config_exist = True
             logger.info("Reading existing configuration file")
-            config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+            config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
             lastcheck = config.get("main", "lastcheck")
             lastversion = config.get("main", "lastdl")
             installedversion = config.get("main", "installed")
@@ -198,7 +185,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             logger.debug("No previous config found")
             self.btn_oneclick.hide()
             config_exist = False
-            config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+            config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
             config.add_section("main")
             config.set("main", "path", "")
             lastcheck = "Never"
@@ -207,7 +194,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             config.set("main", "installed", "")
             config.set("main", "launcher", "")
             config.set("main", "flavor", "")
-            with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini", "w") as f:
+            with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini", "w") as f:
                 config.write(f)
         self.btn_cancel.hide()
         self.frm_progress.hide()
@@ -268,9 +255,9 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             url = "https://api.github.com/repos/acon3d/ABLER/releases"
         # Do path settings save here, in case user has manually edited it
         global config
-        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
         config.set("main", "path", dir_)
-        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini", "w") as f:
+        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini", "w") as f:
             config.write(f)
         f.close()
         try:
@@ -303,8 +290,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 self.btn_execute.clicked.connect(self.exec_linux)
         finallist = results
         if len(finallist) != 0:
-            if installedversion is None or installedversion is "":
-                installedversion = "0.0.0"
             if StrictVersion(finallist[0]["version"]) > StrictVersion(installedversion):
                 self.btn_update.show()
                 self.btn_update.clicked.connect(
@@ -347,10 +332,10 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             url = "https://api.github.com/repos/acon3d/ABLER/releases"
         # Do path settings save here, in case user has manually edited it
         global config
-        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
         launcher_installed = config.get("main", "launcher")
         config.set("main", "path", dir_)
-        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini", "w") as f:
+        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini", "w") as f:
             config.write(f)
         f.close()
         try:
@@ -384,9 +369,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 self.btn_execute.clicked.connect(self.exec_linux)
         finallist = results
         if len(finallist) != 0:
-            print(launcher_installed)
-            if launcher_installed is None or launcher_installed is "":
-                launcher_installed = "0.0.0"
             if StrictVersion(finallist[0]["version"]) > StrictVersion(launcher_installed):
                 self.btn_execute.hide()
                 self.btn_update.hide()
@@ -417,12 +399,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         size_readable = self.hbytes(float(totalsize))
 
         global config
-        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
         config.set("main", "path", dir_)
         config.set("main", "flavor", variation)
         config.set("main", "installed", version)
 
-        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini", "w") as f:
+        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini", "w") as f:
             config.write(f)
         f.close()
 
@@ -476,11 +458,11 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         size_readable = self.hbytes(float(totalsize))
 
         global config
-        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini")
+        config.read(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini")
         config.set("main", "launcher", version)
         logger.info(f"1 {config.get('main', 'installed')}")
 
-        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\config.ini", "w") as f:
+        with open(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\config.ini", "w") as f:
             config.write(f)
         f.close()
 
@@ -599,33 +581,23 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         )
         try:
             if test_arg:
-                _ = subprocess.Popen([os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\AblerLauncher.exe", "--test"])
+                _ = subprocess.Popen([os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.exe", "--test"])
             else:
-                _ = subprocess.Popen(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.96\\updater\\AblerLauncher.exe")
+                _ = subprocess.Popen(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.exe")
             QtCore.QCoreApplication.instance().quit()
         except Exception as e:
             logger.error(e)
-            try:
-                if test_arg:
-                    _ = subprocess.Popen([os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.exe", "--test"])
-                else:
-                    _ = subprocess.Popen(os.getenv('APPDATA') + "\\Blender Foundation\\Blender\\2.93\\updater\\AblerLauncher.exe")
-                QtCore.QCoreApplication.instance().quit()
-            except Exception as ee:
-                logger.error(ee)
-                QtCore.QCoreApplication.instance().quit()
+            QtCore.QCoreApplication.instance().quit()
 
-        
 
 
     def exec_windows(self):
         _ = subprocess.Popen(os.path.join('"' + dir_ + "\\blender.exe" + '"'))
         logger.info(f"Executing {dir_}blender.exe")
-        QtCore.QCoreApplication.instance().quit()
 
     def exec_osx(self):
         BlenderOSXPath = os.path.join(
-            '"' + dir_ + "\\ABLER.app/Contents/MacOS/Abler" + '"'
+            '"' + dir_ + "\\blender.app/Contents/MacOS/blender" + '"'
         )
         os.system("chmod +x " + BlenderOSXPath)
         _ = subprocess.Popen(BlenderOSXPath)
@@ -647,4 +619,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
- 현재 0.1.0 버전의 test launcher에 --test 아규먼트를 추가해서 테스팅에 사용할 수 있도록 하였습니다.
- 그 이후 배포될 런처 버전에서 2-depth exception handling을 사용해서 0.1.0에서 0.1.2또는 그 이후 버전으로 업데이트를 하게 되는 사용자가 있더라도 에러가 나지 않도록 핸들링 하였습니다.