### PR TITLE
initial open function for enforced userpref saving

### DIFF
--- a/source/blender/windowmanager/intern/wm_splash_screen.c
+++ b/source/blender/windowmanager/intern/wm_splash_screen.c
@@ -236,11 +236,14 @@ static uiBlock *wm_block_create_splash(bContext *C, ARegion *region, void *UNUSE
 
   /* Draw setup screen if no preferences have been saved yet. */
   if (!BLI_exists(userpref)) {
-    mt = WM_menutype_find("WM_MT_splash_quick_setup", true);
+    // call WM_OT_save_userpref to automatically save the default setting
+    WM_operator_name_call(C, "WM_OT_save_userpref", WM_OP_EXEC_DEFAULT, NULL);
+    // mt = WM_menutype_find("WM_MT_splash_quick_setup", true);
+    mt = WM_menutype_find("WM_MT_splash", true);
 
     /* The UI_BLOCK_QUICK_SETUP flag prevents the button text from being left-aligned,
        as it is for all menus due to the UI_BLOCK_LOOP flag, see in 'ui_def_but'. */
-    UI_block_flag_enable(block, UI_BLOCK_QUICK_SETUP);
+    // UI_block_flag_enable(block, UI_BLOCK_QUICK_SETUP);
   }
   else {
     mt = WM_menutype_find("WM_MT_splash", true);


### PR DESCRIPTION
userpref와 startup의 탈출을 바라보았을떄
userpref와 startup이 config 폴더에 없으면 save 2.96 setting과 save new setting의 버튼이 있는 quick setting이 떠서 유저들이 아무 버튼이나 누르게 되면 너무나 쉽게 저희가 의도한 방향과 다른 세팅을 가지게 될 수 있습니다. 

그래서 userpref의 모든 정보는 코드로 같이 빌드하고, 그 세팅을 강제로 저장시켜버리는 로직이 필요해진 것 같아서 해당 기능을 작업했습니다.