### PR TITLE
bugfix for illegal byte sequence error on render

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -83,9 +83,12 @@ class Acon3dRenderAllOperator(bpy.types.Operator, ImportHelper):
         self.initial_display_type = context.preferences.view.render_display_type
 
         context.preferences.view.render_display_type = "NONE"
+        outDirName = self.filepath
+        if ".blend" in self.filepath or "." in self.filepath:
+            outDirName = self.filepath.split(".")[0]
 
         for scene in bpy.data.scenes:
-            scene.render.filepath = self.filepath + "\\" + scene.name
+            scene.render.filepath = outDirName + "\\" + scene.name
             self.renderQueue.append(scene)
 
         bpy.app.handlers.render_pre.append(self.pre_render)


### PR DESCRIPTION
acon3d.render_all에서 self.filepath에 .blend 또는 .이 들어갈 시에 폴더명을 .blend 포함하는 이름으로 설정을 하게되어 file save에서 나오는 illegal byte sequence 에러가 생깁니다.

그래서 .blend 또는 .이 들어갈 때에는 self.filepath.split('.')[0]을 디렉토리이름으로 사용하게 해서 오류를 해결했습니다.