### PR TITLE
login ID remember

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ waveletNoiseTile.bin
 /launcher_abler/__pycache__
 
 update.xml
+*.spec
+/build
 /launch_abler/config.ini
 
 .DS_STORE

--- a/release/datafiles/locale/po/ko.po
+++ b/release/datafiles/locale/po/ko.po
@@ -93045,6 +93045,10 @@ msgid "Please login with your ACON3D account."
 msgstr "에이콘3D 계정으로 로그인해주세요."
 
 
+msgid "Remember Username"
+msgstr "아이디 기억하기"
+
+
 msgid "Username"
 msgstr "아이디"
 

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -23,8 +23,8 @@ import platform
 from bpy.app.handlers import persistent
 import requests, webbrowser, pickle, os
 from .lib.remember_id import (
+    delete_remembered_id,
     read_remembered_checkbox,
-    remember_checkbox,
     remember_id,
     read_remembered_id,
 )
@@ -241,12 +241,11 @@ def requestLogin():
             pickle.dump(cookie_final, cookiesFile)
             cookiesFile.close()
 
-            remember_checkbox(prop.remember_username)
-
-            if prop.remember_username:  # 체크박스가 선택된 상태라면
+            read_remembered_checkbox()
+            if prop.remember_username:
                 remember_id(prop.username)
             else:
-                pass  # 파일 실제로 삭제할지 추후 고려
+                delete_remembered_id()
 
             prop.username = ""
             prop.password = ""
@@ -348,7 +347,8 @@ def open_credential_modal(dummy):
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
     prop = userInfo.ACON_prop
-    prop.remember_username = read_remembered_checkbox()
+    if os.path.isfile(path_cookiesFile):
+        prop.remember_username = read_remembered_checkbox()
     if prop.remember_username:
         prop.username = read_remembered_id()
 

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -22,6 +22,12 @@ import ctypes
 import platform
 from bpy.app.handlers import persistent
 import requests, webbrowser, pickle, os
+from .lib.remember_id import (
+    read_remembered_checkbox,
+    remember_checkbox,
+    remember_id,
+    read_remembered_id,
+)
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -235,6 +241,13 @@ def requestLogin():
             pickle.dump(cookie_final, cookiesFile)
             cookiesFile.close()
 
+            remember_checkbox(prop.remember_username)
+
+            if prop.remember_username:  # 체크박스가 선택된 상태라면
+                remember_id(prop.username)
+            else:
+                pass  # 파일 실제로 삭제할지 추후 고려
+
             prop.username = ""
             prop.password = ""
             prop.password_shown = ""
@@ -325,12 +338,24 @@ def open_credential_modal(dummy):
 
         if token:
             userInfo.ACON_prop.login_status = "SUCCESS"
+        else:
+            userInfo.ACON_prop.username = read_remembered_id()
 
     except:
         print("Failed to load cookies")
 
     if userInfo.ACON_prop.login_status != "SUCCESS":
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
+
+    # 로그인 시 체크박스 상태를 저장해 실행시 체크박스 상태를 불러옵니다.
+    prop = userInfo.ACON_prop
+    prop.remember_username = read_remembered_checkbox()
+    if prop.remember_username:
+        prop.username = read_remembered_id()
+        # 체크박스가 켜진 상태면 cookies에 저장한 아이디를 받아옵니다.
+    else:
+        prop.username = ""
+        # 체크박스가 꺼진상태에서 로그인하면 remember_username = False가 되어 빈칸으로 남게 합니다.
 
 
 @persistent

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -347,15 +347,10 @@ def open_credential_modal(dummy):
     if userInfo.ACON_prop.login_status != "SUCCESS":
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
-    # 로그인 시 체크박스 상태를 저장해 실행시 체크박스 상태를 불러옵니다.
     prop = userInfo.ACON_prop
     prop.remember_username = read_remembered_checkbox()
     if prop.remember_username:
         prop.username = read_remembered_id()
-        # 체크박스가 켜진 상태면 cookies에 저장한 아이디를 받아옵니다.
-    else:
-        prop.username = ""
-        # 체크박스가 꺼진상태에서 로그인하면 remember_username = False가 되어 빈칸으로 남게 합니다.
 
 
 @persistent

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -22,11 +22,11 @@ import ctypes
 import platform
 from bpy.app.handlers import persistent
 import requests, webbrowser, pickle, os
-from .lib.remember_id import (
-    delete_remembered_id,
+from .lib.remember_username import (
+    delete_remembered_username,
     read_remembered_checkbox,
-    remember_id,
-    read_remembered_id,
+    remember_username,
+    read_remembered_username,
 )
 
 
@@ -242,9 +242,9 @@ def requestLogin():
             cookiesFile.close()
 
             if prop.remember_username:
-                remember_id(prop.username)
+                remember_username(prop.username)
             else:
-                delete_remembered_id()
+                delete_remembered_username()
 
             prop.username = ""
             prop.password = ""
@@ -346,7 +346,7 @@ def open_credential_modal(dummy):
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
     if prop.remember_username:
-        prop.username = read_remembered_id()
+        prop.username = read_remembered_username()
 
 
 @persistent

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -241,7 +241,6 @@ def requestLogin():
             pickle.dump(cookie_final, cookiesFile)
             cookiesFile.close()
 
-            read_remembered_checkbox()
             if prop.remember_username:
                 remember_id(prop.username)
             else:
@@ -312,7 +311,8 @@ def open_credential_modal(dummy):
     prefs.view.show_splash = True
 
     userInfo = bpy.data.meshes.new("ACON_userInfo")
-    userInfo.ACON_prop.login_status = "IDLE"
+    prop = userInfo.ACON_prop
+    prop.login_status = "IDLE"
 
     try:
         path = bpy.utils.resource_path("USER")
@@ -324,6 +324,7 @@ def open_credential_modal(dummy):
 
         if not os.path.exists(path_cookiesFile):
             raise
+        prop.remember_username = read_remembered_checkbox()
 
         cookiesFile = open(path_cookiesFile, "rb")
         cookies = pickle.load(cookiesFile)
@@ -336,9 +337,7 @@ def open_credential_modal(dummy):
         token = responseData["accessToken"]
 
         if token:
-            userInfo.ACON_prop.login_status = "SUCCESS"
-        else:
-            userInfo.ACON_prop.username = read_remembered_id()
+            prop.login_status = "SUCCESS"
 
     except:
         print("Failed to load cookies")
@@ -346,9 +345,6 @@ def open_credential_modal(dummy):
     if userInfo.ACON_prop.login_status != "SUCCESS":
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
-    prop = userInfo.ACON_prop
-    if os.path.isfile(path_cookiesFile):
-        prop.remember_username = read_remembered_checkbox()
     if prop.remember_username:
         prop.username = read_remembered_id()
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -348,9 +348,6 @@ class AconMeshProperty(bpy.types.PropertyGroup):
         else:
             self.password = self.password_shown
 
-    def toggle_remember_username(self, context):
-        pass
-
     username: bpy.props.StringProperty(name="Username", description="Username")
 
     password: bpy.props.StringProperty(
@@ -365,9 +362,8 @@ class AconMeshProperty(bpy.types.PropertyGroup):
         name="Show Password", default=False, update=toggle_show_password
     )
 
-    remember_username: bpy.props.BoolProperty(
-        name="Remember Username", default=True, update=toggle_remember_username
-    )  # description 달기
+    # TODO: description 달기
+    remember_username: bpy.props.BoolProperty(name="Remember Username", default=True)
 
     login_status: bpy.props.StringProperty(
         name="Login Status",

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -348,6 +348,9 @@ class AconMeshProperty(bpy.types.PropertyGroup):
         else:
             self.password = self.password_shown
 
+    def toggle_remember_username(self, context):
+        pass
+
     username: bpy.props.StringProperty(name="Username", description="Username")
 
     password: bpy.props.StringProperty(
@@ -361,6 +364,10 @@ class AconMeshProperty(bpy.types.PropertyGroup):
     show_password: bpy.props.BoolProperty(
         name="Show Password", default=False, update=toggle_show_password
     )
+
+    remember_username: bpy.props.BoolProperty(
+        name="Remember Username", default=True, update=toggle_remember_username
+    )  # description 달기
 
     login_status: bpy.props.StringProperty(
         name="Login Status",

--- a/release/scripts/startup/abler/lib/remember_id.py
+++ b/release/scripts/startup/abler/lib/remember_id.py
@@ -3,18 +3,18 @@ import bpy, pickle, os
 
 path = bpy.utils.resource_path("USER")
 path_cookiesFolder = os.path.join(path, "cookies")
-path_cookiesID = os.path.join(path_cookiesFolder, "userID")
+path_cookies_username = os.path.join(path_cookiesFolder, "username")
 
 
 def remember_id(username):
-    cookiesID = open(path_cookiesID, "wb")
-    pickle.dump(username, cookiesID)
-    cookiesID.close()
+    cookies_username = open(path_cookies_username, "wb")
+    pickle.dump(username, cookies_username)
+    cookies_username.close()
 
 
 def read_remembered_id():
-    if os.path.isfile(path_cookiesID):
-        with open(path_cookiesID, "rb") as fr:
+    if os.path.isfile(path_cookies_username):
+        with open(path_cookies_username, "rb") as fr:
             data = pickle.load(fr)
         return data
     else:
@@ -22,12 +22,12 @@ def read_remembered_id():
 
 
 def delete_remembered_id():
-    if os.path.isfile(path_cookiesID):
-        os.remove(path_cookiesID)
+    if os.path.isfile(path_cookies_username):
+        os.remove(path_cookies_username)
 
 
 def read_remembered_checkbox():
-    if os.path.isfile(path_cookiesID):
+    if os.path.isfile(path_cookies_username):
         return True
     else:
         return False

--- a/release/scripts/startup/abler/lib/remember_id.py
+++ b/release/scripts/startup/abler/lib/remember_id.py
@@ -3,19 +3,18 @@ import bpy, pickle, os
 
 path = bpy.utils.resource_path("USER")
 path_cookiesFolder = os.path.join(path, "cookies")
-path_cookiesID = os.path.join(path_cookiesFolder, "userID")  #'userID'에 저장
-path_cookiescheck = os.path.join(path_cookiesFolder, "checkbox")
+path_cookiesID = os.path.join(path_cookiesFolder, "userID")
 
 
 def remember_id(username):
 
     cookiesID = open(path_cookiesID, "wb")
-    pickle.dump(username, cookiesID)  # username을 파일에 저장
+    pickle.dump(username, cookiesID)
     cookiesID.close()
 
 
 def read_remembered_id():
-    if os.path.isfile(path_cookiesID):  # 파일이 있는지 없는지 확인
+    if os.path.isfile(path_cookiesID):
         with open(path_cookiesID, "rb") as fr:
             data = pickle.load(fr)
         return data
@@ -23,17 +22,13 @@ def read_remembered_id():
         return ""
 
 
-def remember_checkbox(remember_username):
-
-    cookiescheck = open(path_cookiescheck, "wb")
-    pickle.dump(remember_username, cookiescheck)  # 체크박스 상태를 파일에 저장
-    cookiescheck.close()
+def delete_remembered_id():
+    if os.path.isfile(path_cookiesID):
+        os.remove(path_cookiesID)
 
 
 def read_remembered_checkbox():
-    if os.path.isfile(path_cookiescheck):  # 파일이 있는지 없는지 확인
-        with open(path_cookiescheck, "rb") as fr:
-            data = pickle.load(fr)
-        return data
+    if os.path.isfile(path_cookiesID):
+        return True
     else:
-        return True  # 파일이 없을때(맨 처음 시작시) 체크박스 켜진 상태로
+        return False

--- a/release/scripts/startup/abler/lib/remember_id.py
+++ b/release/scripts/startup/abler/lib/remember_id.py
@@ -7,7 +7,6 @@ path_cookiesID = os.path.join(path_cookiesFolder, "userID")
 
 
 def remember_id(username):
-
     cookiesID = open(path_cookiesID, "wb")
     pickle.dump(username, cookiesID)
     cookiesID.close()

--- a/release/scripts/startup/abler/lib/remember_id.py
+++ b/release/scripts/startup/abler/lib/remember_id.py
@@ -1,0 +1,39 @@
+import bpy, pickle, os
+
+
+path = bpy.utils.resource_path("USER")
+path_cookiesFolder = os.path.join(path, "cookies")
+path_cookiesID = os.path.join(path_cookiesFolder, "userID")  #'userID'에 저장
+path_cookiescheck = os.path.join(path_cookiesFolder, "checkbox")
+
+
+def remember_id(username):
+
+    cookiesID = open(path_cookiesID, "wb")
+    pickle.dump(username, cookiesID)  # username을 파일에 저장
+    cookiesID.close()
+
+
+def read_remembered_id():
+    if os.path.isfile(path_cookiesID):  # 파일이 있는지 없는지 확인
+        with open(path_cookiesID, "rb") as fr:
+            data = pickle.load(fr)
+        return data
+    else:
+        return ""
+
+
+def remember_checkbox(remember_username):
+
+    cookiescheck = open(path_cookiescheck, "wb")
+    pickle.dump(remember_username, cookiescheck)  # 체크박스 상태를 파일에 저장
+    cookiescheck.close()
+
+
+def read_remembered_checkbox():
+    if os.path.isfile(path_cookiescheck):  # 파일이 있는지 없는지 확인
+        with open(path_cookiescheck, "rb") as fr:
+            data = pickle.load(fr)
+        return data
+    else:
+        return True  # 파일이 없을때(맨 처음 시작시) 체크박스 켜진 상태로

--- a/release/scripts/startup/abler/lib/remember_username.py
+++ b/release/scripts/startup/abler/lib/remember_username.py
@@ -6,13 +6,13 @@ path_cookiesFolder = os.path.join(path, "cookies")
 path_cookies_username = os.path.join(path_cookiesFolder, "username")
 
 
-def remember_id(username):
+def remember_username(username):
     cookies_username = open(path_cookies_username, "wb")
     pickle.dump(username, cookies_username)
     cookies_username.close()
 
 
-def read_remembered_id():
+def read_remembered_username():
     if os.path.isfile(path_cookies_username):
         with open(path_cookies_username, "rb") as fr:
             data = pickle.load(fr)
@@ -21,7 +21,7 @@ def read_remembered_id():
         return ""
 
 
-def delete_remembered_id():
+def delete_remembered_username():
     if os.path.isfile(path_cookies_username):
         os.remove(path_cookies_username)
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2742,7 +2742,7 @@ class WM_MT_splash(Menu):
                     icon="CHECKBOX_HLT",
                     emboss=False,
                     invert_checkbox=True,
-                )  # rememeber username checkbox UI
+                )
                 row = column.row()
                 row.prop(
                     userInfo.ACON_prop,

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2734,11 +2734,24 @@ class WM_MT_splash(Menu):
                     row.prop(userInfo.ACON_prop, "password")
 
                 column = row_outside.column()
-                column.separator()
-                column.separator()
-                column.separator()
                 row = column.row()
-                row.prop(userInfo.ACON_prop, "show_password", text="", icon="HIDE_OFF", emboss=False, invert_checkbox=True)
+                row.prop(
+                    userInfo.ACON_prop,
+                    "remember_username",
+                    text="",
+                    icon="CHECKBOX_HLT",
+                    emboss=False,
+                    invert_checkbox=True,
+                )  # rememeber username checkbox UI
+                row = column.row()
+                row.prop(
+                    userInfo.ACON_prop,
+                    "show_password",
+                    text="",
+                    icon="HIDE_OFF",
+                    emboss=False,
+                    invert_checkbox=True,
+                )
 
                 column = row_outside.column()
                 column.scale_x = 0.5

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2732,17 +2732,20 @@ class WM_MT_splash(Menu):
                     row.prop(userInfo.ACON_prop, "password_shown")
                 else:
                     row.prop(userInfo.ACON_prop, "password")
-
-                column = row_outside.column()
                 row = column.row()
-                row.prop(
+                layout.prop(
                     userInfo.ACON_prop,
                     "remember_username",
-                    text="",
+                    text="Remember Username",
                     icon="CHECKBOX_HLT",
                     emboss=False,
                     invert_checkbox=True,
                 )
+
+                column = row_outside.column()
+                column.separator()
+                column.separator()
+                column.separator()
                 row = column.row()
                 row.prop(
                     userInfo.ACON_prop,


### PR DESCRIPTION
- credential_modal.py -> line 244 ~ 251, 352 ~ 360 추가
remember_id.py의 함수들을 추가했습니다. 
로그인 시 아이디와 체크박스 상태를 저장하고 다시 켰을때 체크박스 상태를 받아와 체크박스 상태에 따라 로그인 아이디를 불러오게 할지를 나눴습니다.

- lib폴더 안에 remember_id.py 새로 생성했습니다.
로그인 아이디와 체크박스 상태를 파일에 저장하고 불러오는 함수들을 따로 remember_id.py에 저장했습니다.

- custom_properties.py -> line 339 ~ 340, 356 ~ 358 추가
prop에서 remember_username 인자를 bpy.props.BoolProperty로 정의했습니다.

- wm.py -> line 2911 ~ 2914, 2924 ~ 2931 추가했습니다.
기존 로그인창의 빈자리에 두기위해 column.separate()을 지우고 UI를 추가했습니다.