### PR TITLE
improve use state ui

### DIFF
--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -72,6 +72,8 @@ def toggleUseState(self, context):
                 setattr(obj, att, vector)
                 setattr(prop.state_end, att, vector)
 
+            prop.state_slider = 0
+
         if prop.use_state != use_state:
             prop.use_state = use_state
 

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -42,12 +42,14 @@ class Acon3dStateUpdateOperator(bpy.types.Operator):
     bl_label = "Update State"
     bl_translation_context = "*"
 
+    @classmethod
+    def poll(self, context):
+        x = context.object.ACON_prop.state_slider
+        return 0 < x <= 1
+
     def execute(self, context):
 
         x = context.object.ACON_prop.state_slider
-
-        if not 0 < x <= 1:
-            return {"FINISHED"}
 
         for obj in context.selected_objects:
 


### PR DESCRIPTION
1. Use State를 해제하면 오브젝트의 위치가 시작 state로 돌아갑니다. 이 때 state 슬라이더도 0으로 돌아가도록 변경합니다.
2. State는 시작 위치인 0에서 업데이트할 수 없도록 poll 함수를 추가하였습니다.