### PR TITLE
Sentry integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Mixpanel
 release/scripts/startup/abler/lib/tracker/mixpanel_token
 
+# Sentry
+release/scripts/startup/abler/lib/tracker/sentry_dsn
+
 # python temp paths
 __pycache__/
 *.py[cod]

--- a/abler_requirements.txt
+++ b/abler_requirements.txt
@@ -1,2 +1,3 @@
 mixpanel==4.9.0
 keyboard
+sentry-sdk==1.4.3

--- a/release/scripts/startup/abler/lib/tracker/__init__.py
+++ b/release/scripts/startup/abler/lib/tracker/__init__.py
@@ -1,9 +1,15 @@
 import os
 
-from ._tracker import Tracker, DummyTracker
-from ._mixpanel import MixpanelTracker
+from ._tracker import Tracker, DummyTracker, AggregateTracker
+
+
+def _remote_tracker():
+    from ._mixpanel import MixpanelTracker
+    from ._sentry import SentryTracker
+
+    return AggregateTracker(MixpanelTracker(), SentryTracker())
 
 
 tracker: Tracker = (
-    DummyTracker() if os.environ.get("DISABLE_TRACK") else MixpanelTracker()
+    DummyTracker() if os.environ.get("DISABLE_TRACK") else _remote_tracker()
 )

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -32,7 +32,6 @@ class MixpanelResource:
     def __init__(self, token: str):
         self._consumer = BufferedConsumer(max_size=100)
 
-        print(f"Initializing Mixpanel with token {token}")
         self.mp = Mixpanel(token, consumer=self._consumer)
 
         # NOTE: 로그아웃 후 다른 이메일로 로그인하는 경우는 고려하지 않음
@@ -46,6 +45,7 @@ class MixpanelResource:
             self.tid = "anonymous"
 
         self.flush_repeatedly()
+        print(f"Mixpanel Initialized")
 
     def flush_repeatedly(self):
         # 현재는 cleanup 로직을 두지 않음

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -17,6 +17,7 @@ class SentryTracker(Tracker):
                 sentry_dsn,
                 release=make_release_version(),
             )
+            print(f"Sentry Initialized")
 
     def _enqueue_event(self, event_name: str):
         sentry_sdk.add_breadcrumb(

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -1,13 +1,11 @@
 import os
+import re
 import time
 
 import bpy
 import sentry_sdk
 
 from ._tracker import Tracker
-
-
-release_version = "abler@" + bpy.app.build_hash.decode("ascii")
 
 
 class SentryTracker(Tracker):
@@ -17,7 +15,7 @@ class SentryTracker(Tracker):
             sentry_dsn = f.readline()
             sentry_sdk.init(
                 sentry_dsn,
-                release=release_version,
+                release=make_release_version(),
             )
 
     def _enqueue_event(self, event_name: str):
@@ -27,3 +25,22 @@ class SentryTracker(Tracker):
 
     def _enqueue_email_update(self, email: str):
         sentry_sdk.set_user({"email": email})
+
+
+def make_release_version():
+    """
+    release/v0.0.1 형태의 경우 -> abler.release@0.0.1+hash 형태로 출력.
+    기타 -> abler.devel@hash 형태로 출력.
+    참고: https://docs.sentry.io/platforms/python/configuration/releases/
+    """
+
+    package = "abler.devel"
+    # NOTE: 커밋되지 않은 변경사항이 있는 경우 "branch_name (modified)" 로 출력됨
+    branch = bpy.app.build_branch.decode("utf-8", "replace")
+    version = bpy.app.build_hash.decode("ascii")
+
+    if m := re.match(r"release/v(\d+)\.(\d+)\.(\d+)", branch):
+        package = "abler.release"
+        version = f"{m[1]}.{m[2]}.{m[3]}+{version}"
+
+    return package + "@" + version

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -1,0 +1,29 @@
+import os
+import time
+
+import bpy
+import sentry_sdk
+
+from ._tracker import Tracker
+
+
+release_version = "abler@" + bpy.app.build_hash.decode("ascii")
+
+
+class SentryTracker(Tracker):
+    def __init__(self):
+        super().__init__()
+        with open(os.path.join(os.path.dirname(__file__), "sentry_dsn")) as f:
+            sentry_dsn = f.readline()
+            sentry_sdk.init(
+                sentry_dsn,
+                release=release_version,
+            )
+
+    def _enqueue_event(self, event_name: str):
+        sentry_sdk.add_breadcrumb(
+            category="event", message=event_name, timestamp=time.time()
+        )
+
+    def _enqueue_email_update(self, email: str):
+        sentry_sdk.set_user({"email": email})

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -64,3 +64,17 @@ class DummyTracker(Tracker):
 
     def _enqueue_email_update(self, email: str):
         pass
+
+
+class AggregateTracker(Tracker):
+    def __init__(self, *trackers: Tracker):
+        super().__init__()
+        self.trackers = trackers
+
+    def _enqueue_event(self, event_name: str):
+        for t in self.trackers:
+            t._enqueue_event(event_name)
+
+    def _enqueue_email_update(self, email: str):
+        for t in self.trackers:
+            t._enqueue_email_update(email)


### PR DESCRIPTION
Sentry 설치하고, 기존 tracker 인터페이스를 똑같이 따라해서 사용자 트래킹 이벤트가 발생할 때마다 [Sentry breadcrumb](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/) 남기는 코드를 작성했습니다.

아래와 같이, 예외 발생시 어떤 이벤트가 발생했었는지 기록이 남게 됩니다 (event, Run 부분)
![image](https://user-images.githubusercontent.com/767106/140683952-d6d2e45c-7aa7-4152-93c6-e57948a2ec58.png)

main 으로 바로 들어가는 PR 만들어봤습니다!