### PR TITLE
separate Remember Username

### DIFF
--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2732,15 +2732,17 @@ class WM_MT_splash(Menu):
                     row.prop(userInfo.ACON_prop, "password_shown")
                 else:
                     row.prop(userInfo.ACON_prop, "password")
+                column.separator()
                 row = column.row()
-                layout.prop(
+                row.prop(
                     userInfo.ACON_prop,
                     "remember_username",
-                    text="Remember Username",
+                    text="",
                     icon="CHECKBOX_HLT",
                     emboss=False,
                     invert_checkbox=True,
                 )
+                row.label(text="Remember Username")
 
                 column = row_outside.column()
                 column.separator()


### PR DESCRIPTION
아이디 기억하기 체크박스 해제시 텍스트는 볼드상태를 유지하도록 변경했습니다!

<img width="496" alt="Screen Shot 2021-11-15 at 10 41 20 AM" src="https://user-images.githubusercontent.com/87409148/141709474-a9af85ce-fe9e-4332-9500-347a0cac1383.png">
