### PR TITLE
Improve state UI

### DIFF
--- a/release/datafiles/locale/po/ko.po
+++ b/release/datafiles/locale/po/ko.po
@@ -93313,3 +93313,11 @@ msgctxt "Operator"
 msgid "New Camera"
 msgstr "새로운 카메라"
 
+
+msgctxt "Operator"
+msgid "Do you want to remove state data of selected object(s)?"
+msgstr "선택된 오브젝트의 상태정보를 초기화하시겠어요?"
+
+
+msgid "Use State"
+msgstr "상태정보 사용하기"

--- a/release/datafiles/locale/po/ko.po
+++ b/release/datafiles/locale/po/ko.po
@@ -93314,10 +93314,9 @@ msgid "New Camera"
 msgstr "새로운 카메라"
 
 
-msgctxt "Operator"
-msgid "Do you want to remove state data of selected object(s)?"
-msgstr "선택된 오브젝트의 상태정보를 초기화하시겠어요?"
-
-
 msgid "Use State"
 msgstr "상태정보 사용하기"
+
+
+msgid "Save object's current location / rotation / scale values to state data"
+msgstr "오브젝트의 현재 위치 / 회전 / 스케일 값을 상태정보에 저장합니다."

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -48,13 +48,13 @@ def step(edge0: tuple[float], edge1: tuple[float], x: float) -> tuple[float]:
 
 def toggleUseState(self, context):
 
-    use_state = context.object.ACON_prop.use_state
+    use_state = self.use_state
 
-    for obj in context.selected_objects:
+    if use_state:
 
-        prop = obj.ACON_prop
+        for obj in context.selected_objects:
 
-        if use_state:
+            prop = obj.ACON_prop
 
             if obj == context.object or not prop.use_state:
 
@@ -64,21 +64,18 @@ def toggleUseState(self, context):
                     setattr(prop.state_begin, att, vector)
                     setattr(prop.state_end, att, vector)
 
-        elif obj == context.object or prop.use_state:
+                prop.state_slider = 1
 
-            for att in ["location", "rotation_euler", "scale"]:
+            prop.use_state = True
 
-                vector = getattr(prop.state_begin, att)
-                setattr(obj, att, vector)
-                setattr(prop.state_end, att, vector)
+    else:
 
-        if prop.use_state != use_state:
-            prop.use_state = use_state
+        bpy.ops.acon3d.state_remove("INVOKE_DEFAULT")
 
 
 def moveState(self, context):
 
-    state_slider = context.object.ACON_prop.state_slider
+    state_slider = self.state_slider
 
     for obj in context.selected_objects:
 

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -58,19 +58,33 @@ def toggleUseState(self, context):
 
             if obj == context.object or not prop.use_state:
 
-                for att in ["location", "rotation_euler", "scale"]:
+                if not prop.state_exists:
 
-                    vector = getattr(obj, att)
-                    setattr(prop.state_begin, att, vector)
-                    setattr(prop.state_end, att, vector)
+                    for att in ["location", "rotation_euler", "scale"]:
 
-                prop.state_slider = 1
+                        vector = getattr(obj, att)
+                        setattr(prop.state_begin, att, vector)
+                        setattr(prop.state_end, att, vector)
 
-            prop.use_state = True
+                    prop.state_exists = True
+
+            if not prop.use_state:
+
+                prop.use_state = True
+
+        prop.state_slider = 1
 
     else:
 
-        bpy.ops.acon3d.state_remove("INVOKE_DEFAULT")
+        context.object.ACON_prop.state_slider = 0
+
+        for obj in context.selected_objects:
+
+            prop = obj.ACON_prop
+
+            if prop.use_state:
+
+                prop.use_state = False
 
 
 def moveState(self, context):
@@ -81,7 +95,7 @@ def moveState(self, context):
 
         prop = obj.ACON_prop
 
-        if not prop.use_state:
+        if obj != context.object and not prop.use_state:
             continue
 
         for att in ["location", "rotation_euler", "scale"]:

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -42,12 +42,11 @@ class Acon3dStateUpdateOperator(bpy.types.Operator):
     bl_label = "Update State"
     bl_translation_context = "*"
 
+    @classmethod
+    def poll(cls, context):
+        return context.selected_objects
+
     def execute(self, context):
-
-        x = context.object.ACON_prop.state_slider
-
-        if not 0 < x <= 1:
-            return {"FINISHED"}
 
         for obj in context.selected_objects:
 
@@ -58,12 +57,36 @@ class Acon3dStateUpdateOperator(bpy.types.Operator):
 
             for att in ["location", "rotation_euler", "scale"]:
 
-                vector_begin = getattr(prop.state_begin, att)
-                vector_mid = getattr(obj, att)
-                vector_end = objects.step(vector_begin, vector_mid, 1 / x)
-                setattr(prop.state_end, att, vector_end)
+                vector = getattr(obj, att)
+                setattr(prop.state_end, att, vector)
+
+            prop.state_slider = 1
 
         return {"FINISHED"}
+
+
+class Acon3dStateRemoveOperator(bpy.types.Operator):
+    # This operation acutally does not include removing state data.
+    # Although state data gets lost when being initiated by toggling 'use_state' on.
+    # Hence toggling 'use_state' off means users can not access to state data any more.
+    """Remove object's state data"""
+
+    bl_idname = "acon3d.state_remove"
+    bl_label = "Do you want to remove state data of selected object(s)?"
+    bl_translation_context = "*"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    def execute(self, context):
+
+        for obj in context.selected_objects:
+            prop = obj.ACON_prop
+            prop.state_slider = 0
+            prop.use_state = False
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_confirm(self, event)
 
 
 class Acon3dStateActionOperator(bpy.types.Operator):
@@ -152,6 +175,7 @@ class ObjectSubPanel(bpy.types.Panel):
 classes = (
     Acon3dStateActionOperator,
     Acon3dStateUpdateOperator,
+    Acon3dStateRemoveOperator,
     Acon3dObjectPanel,
     ObjectSubPanel,
 )

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -32,11 +32,10 @@ bl_info = {
 
 
 import bpy
-from .lib import objects
 
 
 class Acon3dStateUpdateOperator(bpy.types.Operator):
-    """Update object's state using current state position and location / rotation / scale values"""
+    """Save object's current location / rotation / scale values to state data"""
 
     bl_idname = "acon3d.state_update"
     bl_label = "Update State"
@@ -60,33 +59,9 @@ class Acon3dStateUpdateOperator(bpy.types.Operator):
                 vector = getattr(obj, att)
                 setattr(prop.state_end, att, vector)
 
-            prop.state_slider = 1
+        context.object.ACON_prop.state_slider = 1
 
         return {"FINISHED"}
-
-
-class Acon3dStateRemoveOperator(bpy.types.Operator):
-    # This operation acutally does not include removing state data.
-    # Although state data gets lost when being initiated by toggling 'use_state' on.
-    # Hence toggling 'use_state' off means users can not access to state data any more.
-    """Remove object's state data"""
-
-    bl_idname = "acon3d.state_remove"
-    bl_label = "Do you want to remove state data of selected object(s)?"
-    bl_translation_context = "*"
-    bl_options = {"REGISTER", "INTERNAL"}
-
-    def execute(self, context):
-
-        for obj in context.selected_objects:
-            prop = obj.ACON_prop
-            prop.state_slider = 0
-            prop.use_state = False
-
-        return {"FINISHED"}
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_confirm(self, event)
 
 
 class Acon3dStateActionOperator(bpy.types.Operator):
@@ -175,7 +150,6 @@ class ObjectSubPanel(bpy.types.Panel):
 classes = (
     Acon3dStateActionOperator,
     Acon3dStateUpdateOperator,
-    Acon3dStateRemoveOperator,
     Acon3dObjectPanel,
     ObjectSubPanel,
 )


### PR DESCRIPTION
This PR creates following changes to UI

1. Turning on `Use State` moves state slider to 1.0
2. Turning off `Use State` moves state slider to 0.0
3. Turning off `Use State` does not remove state data
4. `Update State` button moves state slider to 1.0, updates `end_state` instead of `mid_state`