### PR TITLE
allow CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/build_files/cmake/platform/platform_apple_xcode.cmake
+++ b/build_files/cmake/platform/platform_apple_xcode.cmake
@@ -23,7 +23,7 @@
 # set(CMAKE_OSX_ARCHITECTURES "arm64")
 # message(STATUS "${ARCHITECTURE}")
 # Detect processor architecture.
-# if(NOT CMAKE_OSX_ARCHITECTURES)
+if(NOT CMAKE_OSX_ARCHITECTURES)
 execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND sysctl -q hw.optional.arm64
             OUTPUT_VARIABLE _sysctl_stdout
@@ -35,7 +35,7 @@ if(_sysctl_result EQUAL 0 AND _sysctl_stdout MATCHES "hw.optional.arm64: 1")
 endif()
 message(STATUS "Detected native architecture ${ARCHITECTURE}.")
 set(CMAKE_OSX_ARCHITECTURES ${ARCHITECTURE})
-# endif()
+endif()
 
 # Detect developer directory. Depending on configuration this may be either
 # an Xcode or Command Line Tools installation.


### PR DESCRIPTION
현재 맥에서 컨버터 작업을 하려면 반드시 x86_64(인텔맥)용 빌드를 해야 하는데, 
해당 빌드 옵션(CMAKE_OSX_ARCHITECTURES)이 비활성화되어 있어서 `feature/converter-submodule` 브랜치에서는 다시 이 설정을 쓸 수 있도록 cmake 스크립트를 수정했었습니다.

이 내용을 main 브랜치에도 넣어야 할 필요가 있습니다. 맥에서 컨버터 작업과 에이블러 작업을 병행하려면 main 브랜치 역시 x86_64 빌드를 허용해 줄 필요가 있습니다.