### PR TITLE
add alias tid to email

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -80,4 +80,4 @@ class MixpanelTracker(Tracker):
     def _enqueue_email_update(self, email: str):
         self._ensure_resource()
         self._r.mp.people_set_once(self._r.tid, {"$email": email})
-        self._r.mp.alias(self._r.tid,email)
+        self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -80,3 +80,4 @@ class MixpanelTracker(Tracker):
     def _enqueue_email_update(self, email: str):
         self._ensure_resource()
         self._r.mp.people_set_once(self._r.tid, {"$email": email})
+        self._r.mp.alias(self._r.tid,email)


### PR DESCRIPTION
mixpanel에서 식별자가 달라도 username이 같은 경우 같은 active-user로 보도록 추가했습니다!