### PR TITLE
tracking fly button in general

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1088,7 +1088,7 @@ def km_view3d(params):
         ),
         *(() if not params.use_pie_click_drag else
           (("view3d.navigate", {"type": 'ACCENT_GRAVE', "value": 'CLICK'}, None),)),
-        ("view3d.navigate", {"type": 'ACCENT_GRAVE', "value": 'PRESS', "shift": True}, None),
+        ("acon3d.fly_mode", {"type": 'ACCENT_GRAVE', "value": 'PRESS', "shift": True}, None),
         # Numpad views.
         ("view3d.view_camera", {"type": 'NUMPAD_0', "value": 'PRESS'}, None),
         ("view3d.view_axis", {"type": 'NUMPAD_1', "value": 'PRESS'},
@@ -1619,11 +1619,6 @@ def km_graph_editor(params):
         ("marker.rename", {"type": 'M', "value": 'PRESS', "ctrl": True}, None),
         *_template_items_context_menu("GRAPH_MT_context_menu", params.context_menu_event),
     ])
-            (
-                "acon3d.fly_mode",
-                {"type": "ACCENT_GRAVE", "value": "PRESS", "shift": True},
-                None,
-            ),
 
     if not params.legacy:
         items.extend([

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -20,6 +20,8 @@
 # ------------------------------------------------------------------------------
 # Configurable Parameters
 
+# fmt: off
+
 class Params:
     __slots__ = (
         "apple",

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1619,6 +1619,11 @@ def km_graph_editor(params):
         ("marker.rename", {"type": 'M', "value": 'PRESS', "ctrl": True}, None),
         *_template_items_context_menu("GRAPH_MT_context_menu", params.context_menu_event),
     ])
+            (
+                "acon3d.fly_in_general",
+                {"type": "ACCENT_GRAVE", "value": "PRESS", "shift": True},
+                None,
+            ),
 
     if not params.legacy:
         items.extend([

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1620,7 +1620,7 @@ def km_graph_editor(params):
         *_template_items_context_menu("GRAPH_MT_context_menu", params.context_menu_event),
     ])
             (
-                "acon3d.fly_in_general",
+                "acon3d.fly_mode",
                 {"type": "ACCENT_GRAVE", "value": "PRESS", "shift": True},
                 None,
             ),

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -111,7 +111,7 @@ class Acon3dViewPanel(bpy.types.Panel):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.
-        layout.operator("view3d.walk", text="Fly (shift + `)", text_ctxt="*")
+        layout.operator("acon3d.fly_mode")
 
         cam = context.scene.camera
         if cam is not None:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -135,12 +135,12 @@ class ToggleToolbarOperator(bpy.types.Operator):
 class FlyOperator(bpy.types.Operator):
     """Fly Mode"""
 
-    bl_idname = "acon3d.fly_in_general"
+    bl_idname = "acon3d.fly_mode"
     bl_label = "Fly (shift + `)"
     bl_translation_context = "*"
 
     def execute(self, context):
-        tracker.fly_in_general()
+        tracker.fly_mode()
 
         if context.space_data.type == "VIEW_3D":
             bpy.ops.view3d.walk("INVOKE_DEFAULT")
@@ -178,7 +178,7 @@ class Acon3dImportPanel(bpy.types.Panel):
         row = layout.row()
         row.operator("acon3d.context_toggle")
         row = layout.row()
-        row.operator("acon3d.fly_in_general")
+        row.operator("acon3d.fly_mode")
 
 
 classes = (

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -178,7 +178,7 @@ class Acon3dImportPanel(bpy.types.Panel):
         row = layout.row()
         row.operator("acon3d.context_toggle")
         row = layout.row()
-        row.operator("acon3d.flymode1", text_ctxt="*")
+        row.operator("acon3d.flymode1")
 
 
 classes = (

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -135,7 +135,7 @@ class ToggleToolbarOperator(bpy.types.Operator):
 class FlyOperator(bpy.types.Operator):
     """Fly Mode"""
 
-    bl_idname = "acon3d.flymode1"
+    bl_idname = "acon3d.fly_in_general"
     bl_label = "Fly (shift + `)"
     bl_translation_context = "*"
 
@@ -178,7 +178,7 @@ class Acon3dImportPanel(bpy.types.Panel):
         row = layout.row()
         row.operator("acon3d.context_toggle")
         row = layout.row()
-        row.operator("acon3d.flymode1")
+        row.operator("acon3d.fly_in_general")
 
 
 classes = (

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -132,6 +132,22 @@ class ToggleToolbarOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class FlyOperator(bpy.types.Operator):
+    """Fly Mode"""
+
+    bl_idname = "acon3d.flymode1"
+    bl_label = "Fly (shift + `)"
+    bl_translation_context = "*"
+
+    def execute(self, context):
+        tracker.fly_in_general()
+
+        if context.space_data.type == "VIEW_3D":
+            bpy.ops.view3d.walk("INVOKE_DEFAULT")
+
+        return {"FINISHED"}
+
+
 class Acon3dImportPanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_import"
     bl_label = "General"
@@ -162,13 +178,14 @@ class Acon3dImportPanel(bpy.types.Panel):
         row = layout.row()
         row.operator("acon3d.context_toggle")
         row = layout.row()
-        row.operator("view3d.walk", text="Fly (shift + `)", text_ctxt="*")
+        row.operator("acon3d.flymode1", text_ctxt="*")
 
 
 classes = (
     Acon3dImportPanel,
     ToggleToolbarOperator,
     ImportOperator,
+    FlyOperator,
 )
 
 

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -10,6 +10,7 @@ class EventKind(enum.Enum):
     login_auto = "Login Auto"
     render_quick = "Render Quick"
     import_blend = "Import *.blend"
+    fly_in_general = "Fly in General"
     scene_add = "Scene Add"
     look_at_me = "Look At Me"
 
@@ -43,6 +44,7 @@ def accumulate(interval=0):
         return wrapper
 
     return deco
+    
 
 
 class Tracker(metaclass=ABCMeta):
@@ -102,6 +104,9 @@ class Tracker(metaclass=ABCMeta):
     @accumulate()
     def look_at_me(self):
         self._track(EventKind.look_at_me.value)
+
+    def fly_in_general(self):
+        self._track(EventKind.fly_in_general.value)
 
 
 class DummyTracker(Tracker):

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -10,7 +10,7 @@ class EventKind(enum.Enum):
     login_auto = "Login Auto"
     render_quick = "Render Quick"
     import_blend = "Import *.blend"
-    fly_in_general = "Fly in General"
+    fly_mode = "Fly Mode"
     scene_add = "Scene Add"
     look_at_me = "Look At Me"
 
@@ -44,7 +44,6 @@ def accumulate(interval=0):
         return wrapper
 
     return deco
-    
 
 
 class Tracker(metaclass=ABCMeta):
@@ -94,10 +93,10 @@ class Tracker(metaclass=ABCMeta):
 
     def render_quick(self):
         self._track(EventKind.render_quick.value)
-      
+
     def import_blend(self):
         self._track(EventKind.import_blend.value)
-        
+
     def scene_add(self):
         self._track(EventKind.scene_add.value)
 
@@ -105,8 +104,8 @@ class Tracker(metaclass=ABCMeta):
     def look_at_me(self):
         self._track(EventKind.look_at_me.value)
 
-    def fly_in_general(self):
-        self._track(EventKind.fly_in_general.value)
+    def fly_mode(self):
+        self._track(EventKind.fly_mode.value)
 
 
 class DummyTracker(Tracker):


### PR DESCRIPTION
general 패널에 있는 fly 버튼 tracker를 만들었습니다. camera control 패널에 있는 fly 버튼과 구분하기 위해 변수명을 "fly_in_general"로 설정했습니다.
원래는 general 패널에 row.operator("view3d.walk", text="Fly (shift + `)", text_ctxt="*")로 오퍼레이터가 바로 불러오도록 되어있어서 tracking할 수 있도록 class를 새로 만들었습니다!