### PR TITLE
백그라운드 옵션을 켜도 에러가 나지 않게 수정

### DIFF
--- a/release/scripts/startup/abler/__init__.py
+++ b/release/scripts/startup/abler/__init__.py
@@ -33,10 +33,10 @@ bl_info = {
 
 # Main imports
 import bpy
+import sys
 from types import ModuleType
 
 from . import custom_properties
-from . import credential_modal
 from . import general
 from . import scene_control
 from . import edge_control
@@ -52,13 +52,13 @@ from . import operators
 from .lib.tracker import tracker
 
 
+
 # =========================================================================
 # Registration:
 # =========================================================================
 
 importedLibrary = [
     custom_properties,
-    credential_modal,
     general,
     scene_control,
     edge_control,
@@ -72,6 +72,9 @@ importedLibrary = [
     pref,
     operators,
 ]
+if "--background" not in sys.argv:
+    from . import credential_modal
+    importedLibrary.append(credential_modal)
 
 
 def register():

--- a/release/scripts/startup/abler/__init__.py
+++ b/release/scripts/startup/abler/__init__.py
@@ -72,7 +72,7 @@ importedLibrary = [
     pref,
     operators,
 ]
-if "--background" not in sys.argv:
+if "--background" not in sys.argv and "-b" not in sys.argv:
     from . import credential_modal
     importedLibrary.append(credential_modal)
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -12,7 +12,7 @@ def init_setting(dummy):
     prefs_view = prefs.view
     prefs_paths = prefs.filepaths
 
-    if "--background" not in sys.argv:
+    if "--background" not in sys.argv and "-b" not in sys.argv:
         try:
             init_screen = bpy.data.screens["ACON3D"].areas[0].spaces[0]
             init_screen.shading.type = "RENDERED"

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -1,4 +1,5 @@
 import bpy
+import sys
 from bpy.app.handlers import persistent
 from .lib import cameras, shadow, render
 from .lib.materials import materials_setup
@@ -11,21 +12,22 @@ def init_setting(dummy):
     prefs_view = prefs.view
     prefs_paths = prefs.filepaths
 
-    try:
-        init_screen = bpy.data.screens["ACON3D"].areas[0].spaces[0]
-        init_screen.shading.type = "RENDERED"
-        init_screen.show_region_header = False
-        init_screen.show_region_tool_header = False
-        init_screen.show_gizmo = True
-        init_screen.show_gizmo_object_translate = True
-        init_screen.show_gizmo_object_rotate = True
-        init_screen.show_gizmo_object_scale = True
-        init_screen.show_gizmo_navigate = False
-        init_screen.show_gizmo_tool = True
-        init_screen.show_gizmo_context = True
+    if "--background" not in sys.argv:
+        try:
+            init_screen = bpy.data.screens["ACON3D"].areas[0].spaces[0]
+            init_screen.shading.type = "RENDERED"
+            init_screen.show_region_header = False
+            init_screen.show_region_tool_header = False
+            init_screen.show_gizmo = True
+            init_screen.show_gizmo_object_translate = True
+            init_screen.show_gizmo_object_rotate = True
+            init_screen.show_gizmo_object_scale = True
+            init_screen.show_gizmo_navigate = False
+            init_screen.show_gizmo_tool = True
+            init_screen.show_gizmo_context = True
 
-    except:
-        print("Failed to find screen 'ACON3D'")
+        except:
+            print("Failed to find screen 'ACON3D'")
 
     prefs_sys.use_region_overlap = False
     prefs_view.show_layout_ui = True


### PR DESCRIPTION
백그라운드 옵션을 켜고 자동 컨버팅을 돌리는데, `bpy.data.screens`에 접근하는데 크래시가 계속 나서 --background 또는 -b 옵션이 켜져있을 경우에는  해당 데이터를 이용하지 않도록 수정했습니다.