### PR TITLE
tracking all renders

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -20,6 +20,8 @@
 # ------------------------------------------------------------------------------
 # Configurable Parameters
 
+# fmt: off
+
 class Params:
     __slots__ = (
         "apple",
@@ -524,9 +526,9 @@ def km_screen(params):
         ("ed.undo", {"type": 'Z', "value": 'PRESS', "ctrl": True, "repeat": True}, None),
         ("ed.redo", {"type": 'Z', "value": 'PRESS', "shift": True, "ctrl": True, "repeat": True}, None),
         # Render
-        ("render.render", {"type": 'F12', "value": 'PRESS'},
+        ("acon3d.render_quick", {"type": 'F12', "value": 'PRESS'},
          {"properties": [("use_viewport", True)]}),
-        ("render.render", {"type": 'F12', "value": 'PRESS', "ctrl": True},
+        ("acon3d.render_quick", {"type": 'F12', "value": 'PRESS', "ctrl": True},
          {"properties": [("animation", True), ("use_viewport", True)]}),
         ("render.view_cancel", {"type": 'ESC', "value": 'PRESS'}, None),
         ("render.view_show", {"type": 'F11', "value": 'PRESS'}, None),

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -9,6 +9,11 @@ class EventKind(enum.Enum):
     login_fail = "Login Fail"
     login_auto = "Login Auto"
     render_quick = "Render Quick"
+    render_full = "Render Full"
+    render_line = "Render Line"
+    render_shadow = "Render Shadow"
+    render_all_scenes = "Render All Scenes"
+    render_snip = "Render Snip"
     import_blend = "Import *.blend"
     scene_add = "Scene Add"
     look_at_me = "Look At Me"
@@ -92,10 +97,25 @@ class Tracker(metaclass=ABCMeta):
 
     def render_quick(self):
         self._track(EventKind.render_quick.value)
-      
+
+    def render_full(self):
+        self._track(EventKind.render_full.value)
+
+    def render_line(self):
+        self._track(EventKind.render_line.value)
+
+    def render_shadow(self):
+        self._track(EventKind.render_shadow.value)
+
+    def render_all_scenes(self):
+        self._track(EventKind.render_all_scenes.value)
+
+    def render_snip(self):
+        self._track(EventKind.render_snip.value)
+
     def import_blend(self):
         self._track(EventKind.import_blend.value)
-        
+
     def scene_add(self):
         self._track(EventKind.scene_add.value)
 

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -194,6 +194,12 @@ class Acon3dRenderAllOperator(Acon3dRenderOperator):
     bl_label = "Save"
     bl_translation_context = "*"
 
+    def prepare_queue(self, context):
+        tracker.render_all_scenes()
+
+        super().prepare_queue(context)
+        return {"RUNNING_MODAL"}
+
 
 class Acon3dRenderFullOperator(Acon3dRenderOperator):
     """Render according to the set pixel"""
@@ -203,6 +209,8 @@ class Acon3dRenderFullOperator(Acon3dRenderOperator):
     bl_translation_context = "*"
 
     def prepare_queue(self, context):
+        tracker.render_full()
+
         self.render_queue.append(context.scene)
         return {"RUNNING_MODAL"}
 
@@ -259,6 +267,12 @@ class Acon3dRenderShadowOperator(Acon3dRenderTempSceneOperator):
     bl_label = "Shadow Render"
     bl_translation_context = "*"
 
+    def prepare_queue(self, context):
+        tracker.render_shadow()
+
+        super().prepare_queue(context)
+        return {"RUNNING_MODAL"}
+
 
 class Acon3dRenderLineOperator(Acon3dRenderTempSceneOperator):
     """Renders only lines according to the set pixel"""
@@ -268,6 +282,7 @@ class Acon3dRenderLineOperator(Acon3dRenderTempSceneOperator):
     bl_translation_context = "*"
 
     def prepare_queue(self, context):
+        tracker.render_line()
 
         super().prepare_queue(context)
 
@@ -328,6 +343,7 @@ class Acon3dRenderSnipOperator(Acon3dRenderTempSceneOperator):
         render.matchObjectVisibility()
 
     def prepare_queue(self, context):
+        tracker.render_snip()
 
         super().prepare_queue(context)
 


### PR DESCRIPTION
6개의 렌더 오퍼레이터에 tracker를 심어주었습니다.
Acon3dRenderAllOperator와 Acon3dRenderShadowOperator에선 내부에서 심어줄 부분이 없어서 def prepare_queue를 넣고 tracker를 심어준 뒤에 오버라이딩 하는 쪽으로 추가했습니다.
추가로 F12 버튼도 acon3d.render_quick 오퍼레이터로 변경해 트래킹이 가능토록 수정했습니다.