### PR TITLE
tracking file open

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -395,7 +395,7 @@ def km_window(params):
         # Old shortcuts
         items.extend([
             ("wm.save_homefile", {"type": 'U', "value": 'PRESS', "ctrl": True}, None),
-            ("wm.open_mainfile", {"type": 'F1', "value": 'PRESS'}, None),
+            ("acon3d.file_open", {"type": 'F1', "value": 'PRESS'}, None),
             ("wm.link", {"type": 'O', "value": 'PRESS', "ctrl": True, "alt": True}, None),
             ("wm.append", {"type": 'F1', "value": 'PRESS', "shift": True}, None),
             ("wm.save_mainfile", {"type": 'W', "value": 'PRESS', "ctrl": True}, None),
@@ -414,7 +414,7 @@ def km_window(params):
         # File operations
         op_menu("TOPBAR_MT_file_new", {"type": 'N', "value": 'PRESS', "ctrl": True}),
         op_menu("TOPBAR_MT_file_open_recent", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
-        ("wm.open_mainfile", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
+        ("acon3d.file_open", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
         ("wm.save_mainfile", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
         ("wm.save_as_mainfile", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),
         ("wm.quit_blender", {"type": 'Q', "value": 'PRESS', "ctrl": True}, None),

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -22,6 +22,7 @@ import ctypes
 import platform
 from bpy.app.handlers import persistent
 import requests, webbrowser, pickle, os
+from .lib.post_open import tracker_file_open
 from .lib.remember_username import (
     delete_remembered_username,
     read_remembered_checkbox,
@@ -315,10 +316,7 @@ class Acon3dAnchorOperator(bpy.types.Operator):
 @persistent
 def open_credential_modal(dummy):
 
-    # 에이블러 런처로 실행시 파일명은 ""(빈 문자열).
-    # 에이블러용 블렌더 파일을 더블클릭해서 에이블러를 실행했을때는 파일명이 ""이 아니기 때문에 open이라고 간주
-    if bpy.data.filepath != "":
-        tracker.file_open()
+    tracker_file_open()
 
     prefs = bpy.context.preferences
     prefs.view.show_splash = True

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -314,6 +314,12 @@ class Acon3dAnchorOperator(bpy.types.Operator):
 
 @persistent
 def open_credential_modal(dummy):
+
+    # 에이블러 런처로 실행시 파일명은 ""(빈 문자열).
+    # 에이블러용 블렌더 파일을 더블클릭해서 에이블러를 실행했을때는 파일명이 ""이 아니기 때문에 open이라고 간주
+    if bpy.data.filepath != "":
+        tracker.file_open()
+
     prefs = bpy.context.preferences
     prefs.view.show_splash = True
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -144,10 +144,7 @@ class FileOpenOperator(bpy.types.Operator, ImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        # tracker.file_open()
-
         FILEPATH = self.filepath
-
         bpy.ops.wm.open_mainfile(filepath=FILEPATH)
 
         return {"FINISHED"}

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -144,7 +144,7 @@ class FileOpenOperator(bpy.types.Operator, ImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        tracker.file_open()
+        # tracker.file_open()
 
         FILEPATH = self.filepath
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -134,6 +134,25 @@ class ToggleToolbarOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class FileOpenOperator(bpy.types.Operator, ImportHelper):
+    """File Open"""
+
+    bl_idname = "acon3d.file_open"
+    bl_label = "File Open"
+    bl_translation_context = "*"
+
+    filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
+
+    def execute(self, context):
+        tracker.file_open()
+
+        FILEPATH = self.filepath
+
+        bpy.ops.wm.open_mainfile(filepath=FILEPATH)
+
+        return {"FINISHED"}
+
+
 class Acon3dImportPanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_import"
     bl_label = "General"
@@ -150,9 +169,7 @@ class Acon3dImportPanel(bpy.types.Panel):
 
         row = layout.row()
         row.scale_y = 1.0
-        row.operator(
-            "wm.open_mainfile", text="File Open", text_ctxt="*"
-        ).load_ui = False
+        row.operator("acon3d.file_open")
         row.operator("acon3d.import_blend", text="Import")
 
         row = layout.row()
@@ -171,6 +188,7 @@ classes = (
     Acon3dImportPanel,
     ToggleToolbarOperator,
     ImportOperator,
+    FileOpenOperator,
 )
 
 

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -1,0 +1,9 @@
+import bpy
+from .tracker import tracker
+
+
+def tracker_file_open():
+
+    # tracking file_open
+    if bpy.data.filepath != "":
+        tracker.file_open()

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -8,6 +8,7 @@ class EventKind(enum.Enum):
     login = "Login"
     login_fail = "Login Fail"
     login_auto = "Login Auto"
+    file_open = "File Open"
     render_quick = "Render Quick"
     import_blend = "Import *.blend"
     toggle_toolbar = "Toggle Toolbar"
@@ -91,12 +92,15 @@ class Tracker(metaclass=ABCMeta):
     def login_auto(self):
         self._track(EventKind.login_auto.value)
 
+    def file_open(self):
+        self._track(EventKind.file_open.value)
+
     def render_quick(self):
         self._track(EventKind.render_quick.value)
-      
+
     def import_blend(self):
         self._track(EventKind.import_blend.value)
-        
+
     def scene_add(self):
         self._track(EventKind.scene_add.value)
 

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -16,6 +16,8 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+# fmt: off
+
 # <pep8 compliant>
 import bpy
 from bpy.types import Header, Menu, Panel
@@ -286,7 +288,7 @@ class TOPBAR_MT_file(Menu):
 
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
-        layout.operator("wm.open_mainfile", text="Open...", icon='FILE_FOLDER').load_ui = False
+        layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
         layout.menu("TOPBAR_MT_file_open_recent")
         layout.operator("wm.revert_mainfile")
         layout.menu("TOPBAR_MT_file_recover")


### PR DESCRIPTION
tracker를 심은채로 file open 오퍼레이터를 새로 만들어 우측 패널의 버튼과 단축키(ctrl+O)에서 트래킹이 되도록 설정했습니다.

오퍼레이터에 tracker를 심은 상태로는 윈도우 창에서 파일을 더블클릭 시 open 트래킹을 할수 없어, 에이블러 런처를 실행할 시 파일명을 확인하여 빈 문자열(런처로 실행시엔 파일명은 빈 문자열)이 아닐경우 open으로 간주하고 트래킹을 하도록 추가했습니다.