### PR TITLE
refactoring look_at_me

### DIFF
--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -8,10 +8,6 @@ def toggleConstraintToCamera(self, context):
     cameras.makeSureCameraExists()
 
     obj = context.object
-    look_at_me = obj.ACON_prop.constraint_to_camera_rotation_z
-    if look_at_me:
-        tracker.look_at_me()
-
     setConstraintToCameraByObject(obj, context)
 
 

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -32,6 +32,7 @@ bl_info = {
 
 
 import bpy
+from .lib.tracker import tracker
 
 
 class Acon3dStateUpdateOperator(bpy.types.Operator):
@@ -93,6 +94,36 @@ class Acon3dStateActionOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class TurnOffLookAtMeOperator(bpy.types.Operator):
+    """Turn Off"""
+
+    bl_idname = "acon3d.turn_off_look_at_me"
+    bl_label = "Look at me"
+    bl_translation_context = "*"
+
+    def execute(self, context):
+        for obj in context.selected_objects:
+            obj.ACON_prop.constraint_to_camera_rotation_z = False
+
+        return {"FINISHED"}
+
+
+class TurnOnLookAtMeOperator(bpy.types.Operator):
+    """Turn On"""
+
+    bl_idname = "acon3d.turn_on_look_at_me"
+    bl_label = "Look at me"
+    bl_translation_context = "*"
+
+    def execute(self, context):
+        tracker.look_at_me()
+
+        for obj in context.selected_objects:
+            obj.ACON_prop.constraint_to_camera_rotation_z = True
+
+        return {"FINISHED"}
+
+
 class Acon3dObjectPanel(bpy.types.Panel):
     bl_idname = "ACON_PT_Object_Main"
     bl_label = "Object Control"
@@ -115,7 +146,32 @@ class Acon3dObjectPanel(bpy.types.Panel):
 
         if context.object:
             row = col.row()
-            row.prop(context.object.ACON_prop, "constraint_to_camera_rotation_z")
+
+            if all(
+                map(
+                    lambda obj: obj.ACON_prop.constraint_to_camera_rotation_z,
+                    bpy.context.selected_objects,
+                )
+            ):
+                look_at_me = True
+            else:
+                look_at_me = False
+
+            if look_at_me:
+                row.operator(
+                    "acon3d.turn_off_look_at_me",
+                    text="",
+                    emboss=False,
+                    icon="CHECKBOX_HLT",
+                )
+            else:
+                row.operator(
+                    "acon3d.turn_on_look_at_me",
+                    text="",
+                    emboss=False,
+                    icon="CHECKBOX_DEHLT",
+                )
+            row.label(text="Look at me")
 
 
 class ObjectSubPanel(bpy.types.Panel):
@@ -155,6 +211,8 @@ classes = (
     Acon3dStateUpdateOperator,
     Acon3dObjectPanel,
     ObjectSubPanel,
+    TurnOffLookAtMeOperator,
+    TurnOnLookAtMeOperator,
 )
 
 


### PR DESCRIPTION
호이님께서 저번에 말씀해주신 내용을 토대로 ui쪽을 손보면서 TurnOffLookatme와 TurnOnLookatme 두 오퍼레이터를 만들고 TurnOn 오퍼레이터에만 tracker를 심어주었습니다.
![image](https://user-images.githubusercontent.com/87409148/144790924-940a220f-25d3-4f81-9e44-6ae4e2c3ced6.png)
(왼쪽이 현재상태, 오른쪽이 바뀐 ui입니다)
기능상으로는 모두 똑같지만 미세하게 ui가 바꼈으며, 특히 prop으로 생성되는 체크박스와 icon의 체크박스는 차이가 있습니다.
