### PR TITLE
컨버터 브랜치에 .env gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ AblerLauncher.spec
 /build
 
 /.vscode
+.env


### PR DESCRIPTION
.env가 환경에 있을 확률이 높은데 빠르게 gitignore에 추가를 해야 노출이 안될 것 같아서 빠르게 머지 하겠습니다.