### PR TITLE
change .env location

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/__init__.py
+++ b/release/scripts/startup/abler/lib/tracker/__init__.py
@@ -10,7 +10,8 @@ def _remote_tracker(mixpanel_token, sentry_dsn):
     return AggregateTracker(MixpanelTracker(mixpanel_token), SentryTracker(sentry_dsn))
 
 
-load_dotenv(verbose=True)
+dir_path = os.path.dirname(os.path.realpath(__file__))
+load_dotenv(dotenv_path=os.path.join(dir_path, ".env"), override=True, verbose=True)
 sentry_dsn = os.getenv("SENTRY_DSN")
 mixpanel_token = os.getenv("MIXPANEL_TOKEN")
 disable_track = os.getenv("DISABLE_TRACK")


### PR DESCRIPTION
.env 파일을 init.py에서 읽지를 못해, .env파일의 위치와 주소 참조방식을 변경했습니다!
.env 파일은 tracker폴더안에 넣으시면 됩니다(노션에도 내용 수정했습니다).