### PR TITLE
Mixpanel 이벤트에 버전 정보 넣기

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -1,11 +1,12 @@
 import threading
-from typing import Optional
+from typing import Optional, Any
 import os
 from uuid import uuid4
 import threading
 
 from mixpanel import Mixpanel, BufferedConsumer
 import bpy
+
 from ._tracker import Tracker
 
 
@@ -70,9 +71,9 @@ class MixpanelTracker(Tracker):
             self._r = MixpanelResource(self._mixpanel_token)
 
     @_nonblock
-    def _enqueue_event(self, event_name: str):
+    def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         self._ensure_resource()
-        self._r.mp.track(self._r.tid, event_name)
+        self._r.mp.track(self._r.tid, event_name, properties)
 
     @_nonblock
     def _enqueue_email_update(self, email: str):

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -1,5 +1,5 @@
-import os
 import time
+from typing import Any
 
 import bpy
 import sentry_sdk
@@ -17,7 +17,7 @@ class SentryTracker(Tracker):
         )
         print("Sentry Initialized")
 
-    def _enqueue_event(self, event_name: str):
+    def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         sentry_sdk.add_breadcrumb(
             category="event", message=event_name, timestamp=time.time()
         )

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -1,11 +1,11 @@
 import os
-import re
 import time
 
 import bpy
 import sentry_sdk
 
 from ._tracker import Tracker
+from ._versioning import get_version
 
 
 class SentryTracker(Tracker):
@@ -34,12 +34,11 @@ def make_release_version():
     """
 
     package = "abler.devel"
-    # NOTE: 커밋되지 않은 변경사항이 있는 경우 "branch_name (modified)" 로 출력됨
-    branch = bpy.app.build_branch.decode("utf-8", "replace")
     version = bpy.app.build_hash.decode("ascii")
 
-    if m := re.match(r"release/v(\d+)\.(\d+)\.(\d+)", branch):
+    if v := get_version():
+        major, minor, patch = v
         package = "abler.release"
-        version = f"{m[1]}.{m[2]}.{m[3]}+{version}"
+        version = f"{major}.{minor}.{patch}+{version}"
 
     return package + "@" + version

--- a/release/scripts/startup/abler/lib/tracker/_versioning.py
+++ b/release/scripts/startup/abler/lib/tracker/_versioning.py
@@ -1,0 +1,16 @@
+import re
+from typing import Optional
+
+import bpy
+
+
+def get_version() -> Optional[tuple[int, int, int]]:
+    """
+    :return version tuple (major, minor, patch) based on release branch name
+    """
+    branch = bpy.app.build_branch.decode("utf-8", "replace")
+    # NOTE: 커밋되지 않은 변경사항이 있는 경우 "branch_name (modified)" 로 출력됨
+    if m := re.match(r"release/v(\d+)\.(\d+)\.(\d+)", branch):
+        return int(m[1]), int(m[2]), int(m[3])
+    else:
+        return None


### PR DESCRIPTION
- get_version 함수를 분리했습니다.
- track, _enqueue_event 함수에 properties 파라미터를 추가하고, 여기에 버전 정보가 기본으로 들어가도록 만들었습니다.