### PR TITLE
separate file open & login auto

### DIFF
--- a/abler_requirements.txt
+++ b/abler_requirements.txt
@@ -2,3 +2,4 @@ mixpanel==4.9.0
 keyboard
 sentry-sdk==1.4.3
 python-dotenv
+psutil

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -29,6 +29,7 @@ from .lib.remember_username import (
     remember_username,
     read_remembered_username,
 )
+from .lib.login import is_first_open
 from .lib.tracker import tracker
 from .lib.async_task import AsyncTask
 
@@ -349,7 +350,8 @@ def open_credential_modal(dummy):
 
         if token:
             if not fileopen:
-                tracker.login_auto()
+                if is_first_open():
+                    tracker.login_auto()
             prop.login_status = "SUCCESS"
 
     except:

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -316,7 +316,7 @@ class Acon3dAnchorOperator(bpy.types.Operator):
 @persistent
 def open_credential_modal(dummy):
 
-    tracker_file_open()
+    fileopen = tracker_file_open()
 
     prefs = bpy.context.preferences
     prefs.view.show_splash = True
@@ -348,7 +348,8 @@ def open_credential_modal(dummy):
         token = responseData["accessToken"]
 
         if token:
-            tracker.login_auto()
+            if not fileopen:
+                tracker.login_auto()
             prop.login_status = "SUCCESS"
 
     except:

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -349,9 +349,8 @@ def open_credential_modal(dummy):
         token = responseData["accessToken"]
 
         if token:
-            if not fileopen:
-                if is_first_open():
-                    tracker.login_auto()
+            if not fileopen and is_first_open():
+                tracker.login_auto()
             prop.login_status = "SUCCESS"
 
     except:

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -3,8 +3,9 @@ import psutil
 
 def is_first_open():
     # 윈도우에선 blender.exe로 인식
+    # 추후 abler.exe로 만들 경우를 대비
     process_count = sum(
-        i.startswith("ABLER") or i.startswith("blender")
+        i.startswith("ABLER") or i.startswith("blender") or i.startswith("abler")
         for i in (p.name() for p in psutil.process_iter())
     )
     return process_count <= 1

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -15,23 +15,15 @@ def is_first_open():
             m = re.match("(.+?) +(\d+) (.+?) +(\d+) +(\d+.* K).*", task)
             if m is not None:
                 p.append(m.group(1))
-        cnt = 0
-        for i in p:
-            if i.startswith("blender") or i.startswith("ABLER"):
-                cnt += 1
-        if cnt > 1:
-            return False
-        else:
-            return True
+
+        process_count = sum(
+            bool(i.startswith("blender") or i.startswith("ABLER") for i in p)
+        )
+        return process_count <= 1
 
     elif platform.system() == "Darwin":
-        tmp = os.popen("ps -Af").read()
-        proccount = tmp.count("ABLER")
-
-        if proccount > 2:
-            return False
-        else:
-            return True
+        process_count = os.popen("ps -Af").read().count("ABLER")
+        return process_count <= 2
 
     elif platform.system() == "Linux":
         print("Linux")

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -1,30 +1,12 @@
 import re, os
 import subprocess
 import platform
+import psutil
 
 
 def is_first_open():
-    if platform.system() == "Windows":
-        tasks = (
-            subprocess.check_output(["tasklist"])
-            .decode("cp949", "ignore")
-            .split("\r\n")
-        )
-        p = []
-        for task in tasks:
-            m = re.match("(.+?) +(\d+) (.+?) +(\d+) +(\d+.* K).*", task)
-            if m is not None:
-                p.append(m.group(1))
-
-        process_count = sum(
-            bool(i.startswith("blender") or i.startswith("ABLER") for i in p)
-        )
-        return process_count <= 1
-
-    elif platform.system() == "Darwin":
-        process_count = os.popen("ps -Af").read().count("ABLER")
-        return process_count <= 2
-
-    elif platform.system() == "Linux":
-        print("Linux")
-        return None
+    process_count = sum(
+        i.startswith("ABLER") or i.startswith("blender")
+        for i in (p.name() for p in psutil.process_iter())
+    )
+    return process_count <= 1

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -1,6 +1,3 @@
-import re, os
-import subprocess
-import platform
 import psutil
 
 

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -1,24 +1,38 @@
-import re
+import re, os
 import subprocess
+import platform
 
 
 def is_first_open():
-    # 영어일때는 `ignore` 인자 없어도 됨
-    tasks = (
-        subprocess.check_output(["tasklist"]).decode("cp949", "ignore").split("\r\n")
-    )
-    p = []
-    for task in tasks:
-        m = re.match("(.+?) +(\d+) (.+?) +(\d+) +(\d+.* K).*", task)
-        if m is not None:
-            p.append(m.group(1))
-    cnt = 0
+    if platform.system() == "Windows":
+        tasks = (
+            subprocess.check_output(["tasklist"])
+            .decode("cp949", "ignore")
+            .split("\r\n")
+        )
+        p = []
+        for task in tasks:
+            m = re.match("(.+?) +(\d+) (.+?) +(\d+) +(\d+.* K).*", task)
+            if m is not None:
+                p.append(m.group(1))
+        cnt = 0
+        for i in p:
+            if i.startswith("blender") or i.startswith("ABLER"):
+                cnt += 1
+        if cnt > 1:
+            return False
+        else:
+            return True
 
-    for i in p:
-        if i.startswith("blender") or i.startswith("ABLER"):
-            cnt += 1
+    elif platform.system() == "Darwin":
+        tmp = os.popen("ps -Af").read()
+        proccount = tmp.count("ABLER")
 
-    if cnt > 1:
-        return False
-    else:
-        return True
+        if proccount > 2:
+            return False
+        else:
+            return True
+
+    elif platform.system() == "Linux":
+        print("Linux")
+        return None

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -5,6 +5,7 @@ import psutil
 
 
 def is_first_open():
+    # 윈도우에선 blender.exe로 인식
     process_count = sum(
         i.startswith("ABLER") or i.startswith("blender")
         for i in (p.name() for p in psutil.process_iter())

--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -1,0 +1,24 @@
+import re
+import subprocess
+
+
+def is_first_open():
+    # 영어일때는 `ignore` 인자 없어도 됨
+    tasks = (
+        subprocess.check_output(["tasklist"]).decode("cp949", "ignore").split("\r\n")
+    )
+    p = []
+    for task in tasks:
+        m = re.match("(.+?) +(\d+) (.+?) +(\d+) +(\d+.* K).*", task)
+        if m is not None:
+            p.append(m.group(1))
+    cnt = 0
+
+    for i in p:
+        if i.startswith("blender") or i.startswith("ABLER"):
+            cnt += 1
+
+    if cnt > 1:
+        return False
+    else:
+        return True

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -7,3 +7,4 @@ def tracker_file_open():
     # tracking file_open
     if bpy.data.filepath != "":
         tracker.file_open()
+        return True


### PR DESCRIPTION
1. File Open과 Login Auto를 나누었습니다. 파일을 열때 기본 '코니방'이 뜨면 `bpy.data.filepath`에서 ""(빈 문자열)이 뜹니다. 요걸 이용해 File Open 버튼이나 파일을 더블클릭해서 열면 `bpy.data.filepath != ""`이 돼서 file open이라고 인식하고 tracker.file_open()을 실행합니다.

2. Login Auto가 맨 처음 에이블러를 실행했을때만 트래킹되고 창이 열려있는 상태에서 또 에이블러를 킨다면(주로 파일을 더블클릭해서 열때) Login Auto가 트래킹되지 않도록 했습니다. 에이블러를 실행했을 때 시스템 환경창(윈도우에선` subprocess.check_output(["tasklist"]),` 맥에선 `os.popen("ps -Af"))`에서 에이블러가 켜져있는지(윈도우에선 에이블러 실행 시 blender로 떠서 추가했습니다) 확인하고 이미 켜져있다면 Login Auto를 하지 않도록 기작했습니다.