### PR TITLE
add groups in tree structure

### DIFF
--- a/release/scripts/startup/abler/layer_control.py
+++ b/release/scripts/startup/abler/layer_control.py
@@ -43,7 +43,6 @@ class Acon3dCreateGroupOperator(bpy.types.Operator):
     bl_translation_context = "*"
 
     def execute(self, context):
-
         collection = bpy.data.collections.get("Groups")
         if not collection:
             collection = bpy.data.collections.new("Groups")
@@ -55,11 +54,10 @@ class Acon3dCreateGroupOperator(bpy.types.Operator):
         collection.children.link(col_group)
 
         for obj in context.selected_objects:
-
             group_props = obj.ACON_prop.group
             last_group = None
             if len(group_props):
-                last_group_prop = group_props[len(group_props) - 1]
+                last_group_prop = group_props[-1]
                 last_group = bpy.data.collections.get(last_group_prop.name)
 
             if last_group:
@@ -92,7 +90,7 @@ class Acon3dExplodeGroupOperator(bpy.types.Operator):
             if not len(group_props):
                 continue
 
-            last_group_prop = group_props[len(group_props) - 1]
+            last_group_prop = group_props[-1]
 
             root_group = bpy.data.collections.get("Groups")
             if not root_group:


### PR DESCRIPTION
## 변경내용
Create Group, Explode Group을 실행할 때 컬렉션을 생성하는 구조를 변경합니다.
* 기존: 문어발처럼 모든 그룹들이 병렬적으로 생성됩니다.
* 변경후: Parent-Child 구조를 유지하여 직렬 & 병렬 구조로 생성합니다.

## 예시
Create Group했을 때의 outliner
![image](https://user-images.githubusercontent.com/61715204/147372474-35a914be-575b-4828-a55c-8d0d6d431257.png)
Explode Group했을 때 outliner
![image](https://user-images.githubusercontent.com/61715204/147372478-78c31a3c-0f05-4d86-a7ca-16148c8ac2f4.png)
