### PR TITLE
separate load_dotenv

### DIFF
--- a/release/scripts/startup/abler/lib/__init__.py
+++ b/release/scripts/startup/abler/lib/__init__.py
@@ -15,3 +15,5 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # ##### END GPL LICENSE BLOCK #####
+
+from . import config_env

--- a/release/scripts/startup/abler/lib/config_env.py
+++ b/release/scripts/startup/abler/lib/config_env.py
@@ -1,0 +1,17 @@
+import os
+from dotenv import load_dotenv
+
+
+def find_dotenv():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    last_dir = None
+    while last_dir != current_dir:
+        check_path = os.path.join(current_dir, ".env")
+        if os.path.isfile(check_path)
+            return check_path
+
+        parent_dir = os.path.abspath(os.path.join(current_dir, os.path.pardir))
+        last_dir, current_dir = current_dir, parent_dir
+
+
+load_dotenv(dotenv_path=find_dotenv())

--- a/release/scripts/startup/abler/lib/tracker/__init__.py
+++ b/release/scripts/startup/abler/lib/tracker/__init__.py
@@ -1,5 +1,5 @@
 import os
-from dotenv import load_dotenv
+
 from ._tracker import Tracker, DummyTracker, AggregateTracker
 
 
@@ -10,7 +10,6 @@ def _remote_tracker(mixpanel_token, sentry_dsn):
     return AggregateTracker(MixpanelTracker(mixpanel_token), SentryTracker(sentry_dsn))
 
 
-load_dotenv(verbose=True)
 sentry_dsn = os.getenv("SENTRY_DSN")
 mixpanel_token = os.getenv("MIXPANEL_TOKEN")
 disable_track = os.getenv("DISABLE_TRACK")


### PR DESCRIPTION
.env를 ABLER폴더 최상단 루트폴더에 위치한 상태에서 load하기 위해 _walk_to_root와 find_dotenv 함수를 만들어 load_dotenv 하도록 변경했습니다.
또한 load_dotenv가 실행되는 config_env.py를 init에서 실행하도록 from . import config_env 구문을 추가해주었습니다.