### PR TITLE
separate same-name collections

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -55,9 +55,6 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
 
         FILEPATH = self.filepath
 
-        col_imported = bpy.data.collections.new("Imported")
-        context.scene.collection.children.link(col_imported)
-
         col_layers = bpy.data.collections.get("Layers")
         if not col_layers:
             col_layers = bpy.data.collections.new("Layers")
@@ -84,9 +81,6 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
                 if coll.name == child:
                     found = True
 
-            if not found:
-                col_imported.children.link(coll)
-
             if coll.name == "Layers" or (
                 "Layers." in coll.name and len(coll.name) == 10
             ):
@@ -94,12 +88,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
                     added_l_exclude = context.scene.l_exclude.add()
                     added_l_exclude.name = coll_2.name
                     added_l_exclude.value = True
-                    if coll_2.name in col_layers.children.keys():
-                        print("Same Name of Collection Already Exists!!" + coll_2.name)
-                        # coll_2의 이름을 바꿔서 col_layers에 넣어줘야함!
-                        # col_layers.children.link(coll_2)
-                    else:
-                        col_layers.children.link(coll_2)
+                    col_layers.children.link(coll_2)
 
         for obj in data_to.objects:
             if obj.type == "MESH":

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -94,7 +94,12 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
                     added_l_exclude = context.scene.l_exclude.add()
                     added_l_exclude.name = coll_2.name
                     added_l_exclude.value = True
-                    col_layers.children.link(coll_2)
+                    if coll_2.name in col_layers.children.keys():
+                        print("Same Name of Collection Already Exists!!" + coll_2.name)
+                        # coll_2의 이름을 바꿔서 col_layers에 넣어줘야함!
+                        # col_layers.children.link(coll_2)
+                    else:
+                        col_layers.children.link(coll_2)
 
         for obj in data_to.objects:
             if obj.type == "MESH":


### PR DESCRIPTION
<img width="569" alt="스크린샷 2022-01-25 오후 1 56 10" src="https://user-images.githubusercontent.com/87409148/150913783-3fb164d5-6b89-4abb-bd55-2533d58d64c2.png">
Imported 콜렉션 하위에 layers.001이 생겨서 발생하는 문제라 이름만 수정하려다가 Layers콜렉션이 레이어 패널과 관련돼 있으므로 이중으로 있을 필요가 없어보여 Imported 콜렉션을 아예 삭제했습니다!

이미지와 같이 똑같은 파일을 import하면 겹치는 콜렉션 이름에 자동으로 숫자가 바뀌고 있습니다.