### PR TITLE
오브젝트가 속한 모든 레이어가 켜져야 오브젝트가 보여지도록 수정

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -56,8 +56,17 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
     def updateLayerVis(self, context):
         target_layer = bpy.data.collections[self.name]
         for objs in target_layer.objects:
-            objs.hide_viewport = not (self.value)
-            objs.hide_render = not (self.value)
+            belonging_col_names = set(
+                collection.name for collection in objs.users_collection
+            )
+            should_show = all(
+                layer.value
+                for layer in bpy.context.scene.l_exclude
+                if layer.name in belonging_col_names
+            )
+
+            objs.hide_viewport = not should_show
+            objs.hide_render = not should_show
 
     def updateLayerLock(self, context):
         target_layer = bpy.data.collections[self.name]


### PR DESCRIPTION
원래 스케치업에서는 각 오브젝트(그룹, 인스턴스)가 하나의 레이어에만 속할 수 있지만,
에이블러로 컨버팅을 할 때 계층 관계를 풀어헤쳐서 가져오기 때문에, 에이블러에서는 하나의 오브젝트가 여러 레이어(컬렉션)에 속할 수 있습니다.

이 때, 오브젝트가 속한 두 레이어(A, B라고 합시다) 중 A, B 를 모두 끄고 나서 A 를 켜면,

원래는 오브젝트가 보이지 않아야 정상입니다 (A, B 모두 켜져있어야 오브젝트가 보이는 것이 스케치업의 동작 방식)

하지만 현재 로직상 레이어 A를 켜면 레이어 A에 속한 모든 오브젝트를 켜버리기 때문에, 스케치업의 동작 방식과 달라지게 됩니다.

이를 "해당 오브젝트가 속한 모든 레이어가 켜져 있어야 오브젝트를 켠다"로 수정해서 스케치업과 같은 방식으로 동작하게 만들었습니다.

(다만 Layer0 관련해서는 다른 점이 있는데, 이건 오프라인에서 자세히 공유하겠습니다.)

Fixes #58 