### PR TITLE
change_and_reset_value의 scene을 현재 scene으로 변경

### DIFF
--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -11,6 +11,6 @@ def tracker_file_open():
 
 
 def change_and_reset_value():
-    original_value = bpy.data.scenes["Scene"].ACON_prop.edge_min_line_width
-    bpy.data.scenes["Scene"].ACON_prop.edge_min_line_width = 0
-    bpy.data.scenes["Scene"].ACON_prop.edge_min_line_width = original_value
+    original_value = bpy.context.scene.ACON_prop.edge_min_line_width
+    bpy.context.scene.ACON_prop.edge_min_line_width = 0
+    bpy.context.scene.ACON_prop.edge_min_line_width = original_value


### PR DESCRIPTION
현재 change_and_reset_value에서 기본 씬인 "Scene"의 값을 변경해주고 있는데 
유저가 저장할 때 Scene을 삭제할 수 있어서 현재 씬인 context.scene의 값을 변경해주도록 수정했습니다.