### PR TITLE
렌더시 태양 강도가 변경

### DIFF
--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -11,6 +11,13 @@ def tracker_file_open():
 
 
 def change_and_reset_value():
+
+    # line update
     original_value = bpy.context.scene.ACON_prop.edge_min_line_width
     bpy.context.scene.ACON_prop.edge_min_line_width = 0
     bpy.context.scene.ACON_prop.edge_min_line_width = original_value
+
+    # sun update
+    original_value = bpy.context.scene.ACON_prop.sun_strength
+    bpy.context.scene.ACON_prop.sun_strength = 1.0
+    bpy.context.scene.ACON_prop.sun_strength = original_value


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87409148/153319292-166d8cea-d598-4800-979c-6f8f1fb504b8.png)

현재 파일 오픈시 패널엔 강도가 1.0으로 되어있는데 실제론 2.0입니다.
강도의 default-value값을 2.0으로 변경했습니다.
(default-value 값을 바꾸는게 좋을지, 혹은 1.0으로 맞추되 실제론 2.0이 적용되는게 좋을지는 의견 부탁드립니다!)