### PR TITLE
layer0 제외

### DIFF
--- a/release/scripts/startup/abler/layer_control.py
+++ b/release/scripts/startup/abler/layer_control.py
@@ -133,6 +133,10 @@ class Acon3dLayerPanel(bpy.types.Panel):
         for child in collection.children:
             index += 1
 
+            if child.name == "Layer0":
+                findex += 1
+                continue
+
             l_exclude = bpy.context.scene.l_exclude
 
             if findex > len(l_exclude) - 1:


### PR DESCRIPTION
저번에 스듴님이 말씀하신 것처럼 view_layer.layer_collection.children을 바꿔주려고 했는데 요게 리스트가 아니고 collection이라 Layer0만 따로 빼는게 안돼서 차라리 레이어 패널에 직접 그려주는 함수 _draw_collection의 내용을 바꿔주었습니다.
for문에서 collection마다 그려줄때 layer0라는 이름이 있으면 그리지 않고 index와 findex만 값이 더해져서 넘어가도록 해주었습니다(index와 findex가 업데이트 되지 않으면 앞으로 밀립니다).