### PR TITLE
SceneProperty 모두 업데이트

### DIFF
--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -23,7 +23,6 @@ def change_and_reset_value() -> None:
         if type(original_value) == float or type(original_value) == int:
             setattr(bpy.context.scene.ACON_prop, property, original_value)
         elif type(original_value) == bool:
-            # TODO : tracker flag를 심어줘야함.
             setattr(bpy.context.scene.ACON_prop, property, original_value)
 
         # string을 뺀 이유 : EnumProperty에 없는 값을 넣어주면 error가 뜸.

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -14,9 +14,18 @@ def tracker_file_open() -> Optional[bool]:
 
 def change_and_reset_value() -> None:
 
+    # 파일 맨 처음 열었을때 custom properties의 속성들이 업데이트 되지 않는 문제를 해결하기 위해
+    # 만들어둔 함수
+
     properties = AconSceneProperty.__annotations__
     for property in properties:
         original_value = getattr(bpy.context.scene.ACON_prop, property)
         if type(original_value) == float or type(original_value) == int:
-            setattr(bpy.context.scene.ACON_prop, property, 0)
             setattr(bpy.context.scene.ACON_prop, property, original_value)
+        elif type(original_value) == bool:
+            # TODO : tracker flag를 심어줘야함.
+            setattr(bpy.context.scene.ACON_prop, property, original_value)
+
+        # string을 뺀 이유 : EnumProperty에 없는 값을 넣어주면 error가 뜸.
+        # float = 0, bool = False 처럼 공통으로 들어갈 값이 없음.
+        # type 없이 일괄적으로 처리하려고 했으나, EnumProperty에서 error가 나고 에이블러가 멈춰버림

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -16,8 +16,7 @@ def change_and_reset_value() -> None:
 
     properties = AconSceneProperty.__annotations__
     for property in properties:
-        get_property = getattr(bpy.context.scene.ACON_prop, property)
-        original_value = get_property
-        if type(get_property) == float or type(get_property) == int:
+        original_value = getattr(bpy.context.scene.ACON_prop, property)
+        if type(original_value) == float or type(original_value) == int:
             setattr(bpy.context.scene.ACON_prop, property, 0)
             setattr(bpy.context.scene.ACON_prop, property, original_value)

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import bpy
 from .tracker import tracker
+from ..custom_properties import AconSceneProperty
 
 
 def tracker_file_open() -> Optional[bool]:
@@ -13,12 +14,10 @@ def tracker_file_open() -> Optional[bool]:
 
 def change_and_reset_value() -> None:
 
-    # line update
-    original_value = bpy.context.scene.ACON_prop.edge_min_line_width
-    bpy.context.scene.ACON_prop.edge_min_line_width = 0
-    bpy.context.scene.ACON_prop.edge_min_line_width = original_value
-
-    # sun update
-    original_value = bpy.context.scene.ACON_prop.sun_strength
-    bpy.context.scene.ACON_prop.sun_strength = 1.0
-    bpy.context.scene.ACON_prop.sun_strength = original_value
+    properties = AconSceneProperty.__annotations__
+    for property in properties:
+        get_property = getattr(bpy.context.scene.ACON_prop, property)
+        original_value = get_property
+        if type(get_property) == float or type(get_property) == int:
+            setattr(bpy.context.scene.ACON_prop, property, 0)
+            setattr(bpy.context.scene.ACON_prop, property, original_value)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -68,12 +68,19 @@ class Tracker(metaclass=ABCMeta):
     def __init__(self):
         self._agreed = True
         self._default_properties = {}
+        self._enabled = True
 
         if v := get_version():
             major, minor, patch = v
             self._default_properties["version"] = f"{major}.{minor}.{patch}"
         else:
             self._default_properties["version"] = "development"
+
+    def turn_on(self):
+        self._enabled = True
+
+    def turn_off(self):
+        self._enabled = False
 
     @abstractmethod
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
@@ -96,6 +103,8 @@ class Tracker(metaclass=ABCMeta):
     def _track(
         self, event_name: str, properties: Optional[dict[str, Any]] = None
     ) -> bool:
+        if not self._enabled:
+            return False
         if not self._agreed:
             return False
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -40,20 +40,21 @@ def init_setting(dummy):
 @persistent
 def load_handler(dummy):
     tracker.turn_off()
+    try:
+        init_setting(None)
+        cameras.makeSureCameraExists()
+        cameras.switchToRendredView()
+        cameras.turnOnCameraView(False)
+        shadow.setupSharpShadow()
+        render.setupBackgroundImagesCompositor()
+        materials_setup.applyAconToonStyle()
+        for scene in bpy.data.scenes:
+            scene.view_settings.view_transform = "Standard"
 
-    init_setting(None)
-    cameras.makeSureCameraExists()
-    cameras.switchToRendredView()
-    cameras.turnOnCameraView(False)
-    shadow.setupSharpShadow()
-    render.setupBackgroundImagesCompositor()
-    materials_setup.applyAconToonStyle()
-    for scene in bpy.data.scenes:
-        scene.view_settings.view_transform = "Standard"
-
-    scenes.refresh_look_at_me()
-    change_and_reset_value()
-    tracker.turn_on()
+        scenes.refresh_look_at_me()
+        change_and_reset_value()
+    finally:
+        tracker.turn_on()
 
 
 def register():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -3,6 +3,7 @@ from bpy.app.handlers import persistent
 from .lib import cameras, shadow, render, scenes
 from .lib.materials import materials_setup
 from .lib.post_open import change_and_reset_value
+from .lib.tracker import tracker
 
 
 def init_setting(dummy):
@@ -38,6 +39,8 @@ def init_setting(dummy):
 
 @persistent
 def load_handler(dummy):
+    tracker.turn_off()
+
     init_setting(None)
     cameras.makeSureCameraExists()
     cameras.switchToRendredView()
@@ -48,11 +51,9 @@ def load_handler(dummy):
     for scene in bpy.data.scenes:
         scene.view_settings.view_transform = "Standard"
 
-    # refresh look_at_me
     scenes.refresh_look_at_me()
-    
-    # update scene value when file-open
     change_and_reset_value()
+    tracker.turn_on()
 
 
 def register():


### PR DESCRIPTION
`AconSceneProperty.__annotations__`로 AconSceneProperty의 변수들을 모두 가져와 getattrt, setattr을 써서 change_and_reset_value를 변경했습니다.
현재 AconSceneProperty에는 크게 FloatProperty, BoolProperty, StringProperty, EnumProperty가 있는데, 여기서 FloatProperty(+ int, 값이 2면 type이 int로 나와 or연산으로 추가)인 속성만 변경하도록 했습니다. BoolProperty는 기능을 켜고끄는 속성인데 요녀석들을 업데이트해주면 파일을 열때마다 믹스패널이 모든 기능에 트래킹 돼서 빼두었고, str으로 구분되는 StringProperty와 EnumProperty는 특정된 값만 받기때문에 그 값이 없으면 error가 나서 아예 빼두었습니다.
FloatProperty가 파라미터 값들이라 요녀석들만 받아도 될거 같은데 리뷰해주시고 코멘트 편하게 부탁드립니닷!