### PR TITLE
그룹네비게이션 UI

### DIFF
--- a/release/datafiles/locale/po/ko.po
+++ b/release/datafiles/locale/po/ko.po
@@ -93330,7 +93330,7 @@ msgstr "오브젝트의 현재 위치 / 회전 / 스케일 값을 상태정보�
 
 
 msgid "Group Navigation"
-msgstr "그룹 네비게이션"
+msgstr "그룹 내비게이션"
 
 msgid "Group Navigate Top"
 msgstr "최상위 그룹"

--- a/release/datafiles/locale/po/ko.po
+++ b/release/datafiles/locale/po/ko.po
@@ -93327,3 +93327,31 @@ msgstr "상태정보 사용하기"
 
 msgid "Save object's current location / rotation / scale values to state data"
 msgstr "오브젝트의 현재 위치 / 회전 / 스케일 값을 상태정보에 저장합니다."
+
+
+msgid "Group Navigation"
+msgstr "그룹 네비게이션"
+
+msgid "Group Navigate Top"
+msgstr "최상위 그룹"
+
+msgid "Select Top Group"
+msgstr "최상위 그룹 선택하기"
+
+msgid "Group Navigate Up"
+msgstr "상위 그룹"
+
+msgid "Select Upper Group"
+msgstr "상위 그룹 선택하기"
+
+msgid "Group Navigate Down"
+msgstr "하위 그룹"
+
+msgid "Select Lower Group"
+msgstr "하위 그룹 선택하기"
+
+msgid "Group Navigate Bottom"
+msgstr "최하위 그룹"
+
+msgid "Select Bottom Group"
+msgstr "최하위 그룹 선택하기"

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -444,6 +444,11 @@ class AconObjectProperty(bpy.types.PropertyGroup):
 
     group: bpy.props.CollectionProperty(type=AconObjectGroupProperty)
 
+    group_list: bpy.props.EnumProperty(
+        name="View",
+        items=objects.add_group_list_from_collection,
+    )
+
     constraint_to_camera_rotation_z: bpy.props.BoolProperty(
         name="Look at me", default=False, update=objects.toggleConstraintToCamera
     )

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict, List, Union, Tuple, Optional
 import bpy
 from . import cameras
 from .tracker import tracker
@@ -12,6 +13,23 @@ def toggleConstraintToCamera(self, context):
         tracker.look_at_me()
 
     setConstraintToCameraByObject(obj, context)
+
+
+# items should be a global variable due to a bug in EnumProperty
+items: List[Tuple[str, str, str]] = []
+
+
+def add_group_list_from_collection(self, context) -> List[Tuple[str, str, str]]:
+    items.clear()
+
+    obj = context.object
+    items.append((obj.name, obj.name, "", "OUTLINER_OB_MESH", 0))
+
+    if collection := bpy.context.object.ACON_prop.group:
+        for item in collection:
+            items.append((item.name, item.name, "", "OUTLINER_COLLECTION", 1))
+
+    return items
 
 
 def setConstraintToCameraByObject(obj, context=None):

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Union, Tuple, Optional
+from bpy.types import Context
 import bpy
 from . import cameras
 from .tracker import tracker
@@ -19,7 +20,9 @@ def toggleConstraintToCamera(self, context):
 items: List[Tuple[str, str, str]] = []
 
 
-def add_group_list_from_collection(self, context) -> List[Tuple[str, str, str]]:
+def add_group_list_from_collection(
+    self, context: Context
+) -> List[Tuple[str, str, str]]:
     items.clear()
 
     obj = context.object

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -32,6 +32,67 @@ bl_info = {
 
 
 import bpy
+from .lib import layers
+
+
+class GroupNavigateTopOperator(bpy.types.Operator):
+    """Select Top Group"""
+
+    bl_idname = "acon3d.group_navigate_top"
+    bl_label = "Group Navigate Top"
+    bl_translation_context = "*"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object
+
+    def execute(self, context):
+        return {"FINISHED"}
+
+
+class GroupNavigateUpOperator(bpy.types.Operator):
+    """Select Upper Group"""
+
+    bl_idname = "acon3d.group_navigate_up"
+    bl_label = "Group Navigate Up"
+    bl_translation_context = "*"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object
+
+    def execute(self, context):
+        return {"FINISHED"}
+
+
+class GroupNavigateDownOperator(bpy.types.Operator):
+    """Select Lower Group"""
+
+    bl_idname = "acon3d.group_navigate_down"
+    bl_label = "Group Navigate Down"
+    bl_translation_context = "*"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object
+
+    def execute(self, context):
+        return {"FINISHED"}
+
+
+class GroupNavigateBottomOperator(bpy.types.Operator):
+    """Select Bottom Group"""
+
+    bl_idname = "acon3d.group_navigate_bottom"
+    bl_label = "Group Navigate Bottom"
+    bl_translation_context = "*"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object
+
+    def execute(self, context):
+        return {"FINISHED"}
 
 
 class Acon3dStateUpdateOperator(bpy.types.Operator):
@@ -149,11 +210,38 @@ class ObjectSubPanel(bpy.types.Panel):
         row.operator("acon3d.state_update", text="", icon="FILE_REFRESH")
 
 
+class Acon3dGroupNavigaionPanel(bpy.types.Panel):
+    bl_parent_id = "ACON_PT_Object_Main"
+    bl_idname = "ACON_PT_Group_Navigation"
+    bl_label = "Group Navigation"
+    bl_category = "ACON3D"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context):
+        obj = context.object
+        prop = obj.ACON_prop
+        layout = self.layout
+
+        row = layout.row(align=True)
+        row.prop(prop, "group_list", text="")
+        row.operator("acon3d.group_navigate_top", text="", icon="TRIA_UP_BAR")
+        row.operator("acon3d.group_navigate_up", text="", icon="TRIA_UP")
+        row.operator("acon3d.group_navigate_down", text="", icon="TRIA_DOWN")
+        row.operator("acon3d.group_navigate_bottom", text="", icon="TRIA_DOWN_BAR")
+
+
 classes = (
+    GroupNavigateUpOperator,
+    GroupNavigateTopOperator,
+    GroupNavigateDownOperator,
+    GroupNavigateBottomOperator,
     Acon3dStateActionOperator,
     Acon3dStateUpdateOperator,
     Acon3dObjectPanel,
     ObjectSubPanel,
+    Acon3dGroupNavigaionPanel,
 )
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87409148/155448397-70e4d47f-c100-46e9-874c-ad630ee2278e.png)
드롭다운 박스에 active_object와 속한 모든 그룹들을 볼수 있게 해두었습니다. 아이콘을 추가해 오브젝트와 그룹을 분리시켰고, 아래로 갈수록 최상단입니다. 
그 옆엔 4개 operator 버튼을 두었고 코드상에선 빈 `execute(self, context): return`로 두어 요 안에 기능 추가하면 됩니닷
각각의 버튼에 국문 번역도 넣었습니다.