### PR TITLE
퀵렌더시 선택 개체 외곽선 사라지기

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -381,8 +381,6 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator):
     bl_label = "Quick Render"
     bl_translation_context = "*"
 
-    initial_selected_objects = []
-
     def execute(self, context):
         tracker.render_quick()
         return super().execute(context)
@@ -394,21 +392,11 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator):
         scene.render.filepath = os.path.join(filepath, scene.name)
 
         for obj in context.selected_objects:
-            self.initial_selected_objects.append(obj)
             obj.select_set(False)
 
         bpy.ops.render.opengl("INVOKE_DEFAULT", write_still=True)
 
         return {"RUNNING_MODAL"}
-
-    def on_render_finish(self, context):
-
-        for obj in self.initial_selected_objects:
-            obj.select_set(True)
-
-        self.initial_selected_objects.clear()
-
-        return {"FINISHED"}
 
 
 class Acon3dRenderPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -406,6 +406,8 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator):
         for obj in self.initial_selected_objects:
             obj.select_set(True)
 
+        self.initial_selected_objects.clear()
+
         return {"FINISHED"}
 
 


### PR DESCRIPTION
퀵렌더에서 선택 개체를 담는 initial_selected_objects 리스트가 다른 개체를 선택 후 퀵렌더를 실행하면 리스트에 이전 내용이 남겨져 오류가 나고 있었습니다. 그래서 퀵렌더 후 `initial_selected_objects.clear()`로 리스트를 비워주도록 추가했습니다.