### PR TITLE
배경에 쓰인 scene.copy 삭제!

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -336,6 +336,8 @@ class Acon3dRenderSnipOperator(Acon3dRenderTempSceneOperator):
                 *compNodes, snip_layer=self.temp_layer, shade_image=self.temp_image
             )
 
+            os.remove(image_path)
+
         else:
 
             bpy.data.collections.remove(self.temp_col)


### PR DESCRIPTION
현재 snip렌더시 이미지가 3장 나오는데 snip 렌더시 render_snip, render_full 이외에 다른 씬도 저장됩니다. 마지막 녀석은 scene을 복사하고 배경삭제에 쓰이는데 같이 저장돼, 배경으로 쓰고나서 파일 삭제하도록 추가했습니다!