### PR TITLE
render control 리팩토링

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -225,14 +225,9 @@ class Acon3dRenderTempSceneOperator(Acon3dRenderOperator):
     def prepare_queue(self, context):
 
         scene = context.scene.copy()
-        scene.name = f"{context.scene.name}_shadow"
         self.render_queue.append(scene)
         self.temp_scenes.append(scene)
 
-        prop = scene.ACON_prop
-        prop.toggle_texture = False
-        prop.toggle_shading = True
-        prop.toggle_toon_edge = False
         scene.eevee.use_bloom = False
         scene.render.use_lock_interface = True
 
@@ -272,6 +267,14 @@ class Acon3dRenderShadowOperator(Acon3dRenderTempSceneOperator):
         tracker.render_shadow()
 
         super().prepare_queue(context)
+
+        scene = self.render_queue[0]
+        scene.name = f"{context.scene.name}_shadow"
+        prop = scene.ACON_prop
+        prop.toggle_texture = False
+        prop.toggle_shading = True
+        prop.toggle_toon_edge = False
+
         return {"RUNNING_MODAL"}
 
 
@@ -290,6 +293,7 @@ class Acon3dRenderLineOperator(Acon3dRenderTempSceneOperator):
         scene = self.render_queue[0]
         scene.name = f"{context.scene.name}_line"
         prop = scene.ACON_prop
+        prop.toggle_texture = False
         prop.toggle_shading = False
         prop.toggle_toon_edge = True
 

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -355,7 +355,10 @@ class Acon3dRenderSnipOperator(Acon3dRenderTempSceneOperator):
 
         scene = context.scene.copy()
         scene.name = f"{context.scene.name}_snipped"
-        scene.ACON_prop.toggle_shading = False
+        prop = scene.ACON_prop
+        prop.toggle_texture = False
+        prop.toggle_shading = False
+        prop.toggle_toon_edge = False
         self.render_queue.append(scene)
         self.temp_scenes.append(scene)
 


### PR DESCRIPTION
현재 `Acon3dRenderTempSceneOperator`가 shadow 렌더와 동일해 temp 클래스는 필요한 내용만 넣고 shadow 렌더에 해당하는 녀석들은 따로 빼두었습니다. 또한 line 렌더와 snip 렌더에서 temp 클래스에서 받았던 내용들도 추가해주었습니다.