### PR TITLE
그룹 내비게이션 무한루프 버그 픽스

### DIFF
--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -170,6 +170,10 @@ def group_navigate_up(
         except Exception as e:
             print(e)
             return selectByGroup("TOP")
+    # group-group-object의 구조를 가진 경우, UP을 실행해도
+    # 여러번 눌러야 하는 경우가 있음. 그래서 while 문으로
+    # 처리했지만, root group까지 이런 구조인 오브젝트들이
+    # 있어서 for loop로 최대 5회 돌도록 처리함.
     for _ in range(5):
         if len(selection.all_objects) > 1:
             break

--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -170,7 +170,9 @@ def group_navigate_up(
         except Exception as e:
             print(e)
             return selectByGroup("TOP")
-    while len(selection.all_objects) <= 1:
+    for _ in range(5):
+        if len(selection.all_objects) > 1:
+            break
         selection = up(ordered_ancester_collections, selection)
     selected_group_prop.current_group = selection.name
     for obj in selection.all_objects:


### PR DESCRIPTION
### issue
- 그룹 내비게이션에서 UP을 실행할때 하나짜리 그룹 -그룹-오브젝트 의 형식에서 여러번 눌러야 제대로 작동하는 것 같이 보이는 현상을 피하기 위해서 all_object의 길이가 1보다 클 때 루프를 탈출하는 while 문을 사용했음
- 그런데 실제로 최상위그룹-그룹-오브젝트의 구조를 가지는 그룹이 존재했고, 이 때 무한루프가 나타나는 현상이 발생

### 해결
- 최대 5회의 loop 반복으로 바꾸어서 중간에 조건에 부합하면 (all_objects의 길이가 1보다 큼) 루프를 탈출하게 만들어서 타협을 함.