### PR TITLE
투명 재질이 temp scene 렌더 이후 빛을 투과시키지 못하는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -226,6 +226,12 @@ def setMaterialParametersByType(mat: Material) -> None:
     if type == "Clear":
         mat.blend_method = "BLEND"
         mat.ACON_prop.toggle_shadow = False
+        # WORKAROUND:
+        # 렌더 시 필요에 따라 mat.shadow_method = "OPAQUE" 대입을 하는 경우가 있는데,
+        # 렌더가 끝난 후 머티리얼 관련 뒷처리를 할 때
+        # toggle_shadow = False 을 통해 shadow_method 가 원상복구 되기를 기대했으나,
+        # 기대대로 동작하지 않고 "OPAQUE" 상태로 남아서 직접 "NONE" 대입해서 처리
+        mat.shadow_method = "NONE"
         toonNode.inputs[1].default_value = 1
         toonNode.inputs[3].default_value = 1
     elif type == "Diffuse":


### PR DESCRIPTION
Acon3dRenderTempSceneOperator 를 상속받는 렌더 오퍼레이터 실행 이후에 투명 재질이 빛 투과를 하지 못하게 되는 현상을 수정했습니다.

어떤 이유에서인지 toggle_shadow 에 걸려있는 update handler 가 제대로 작동되지 않는 것으로 보여서, 해당 update handler 에서 해 주는 업데이트를 직접 해주는 코드를 추가했습니다. 코드 중복이 발생해서 100% 마음에 들지는 않는 해결책이긴 합니다.