### PR TITLE
fix compositor background image transform calculation

### DIFF
--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -100,16 +100,25 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
 
             tree.links.new(node_scale.outputs[0], node_conditional.inputs[0])
 
+        node_translate = nodes.new("CompositorNodeTranslate")
+        node_translate.use_relative = True
+
+        render_r = scene.render.resolution_y / scene.render.resolution_x
+        image_r = image.size[1] / image.size[0]
+        background_r = render_r / image_r
+        node_translate.inputs[2].default_value = (
+            background_image.offset[1] / background_r
+        )
+        tree.links.new(node_conditional.outputs[0], node_translate.inputs[0])
+
         node_transform = nodes.new("CompositorNodeTransform")
+
         node_transform.inputs[1].default_value = (
             background_image.offset[0] * scene.render.resolution_x
         )
-        node_transform.inputs[2].default_value = (
-            background_image.offset[1] * scene.render.resolution_x * 9 / 8
-        )
         node_transform.inputs[3].default_value = -1 * background_image.rotation
         node_transform.inputs[4].default_value = background_image.scale
-        tree.links.new(node_conditional.outputs[0], node_transform.inputs[0])
+        tree.links.new(node_translate.outputs[0], node_transform.inputs[0])
 
         node_alphaOver = nodes.new("CompositorNodeAlphaOver")
         tree.links.new(node_alphaOver.outputs[0], node_right)

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -105,7 +105,7 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
             background_image.offset[0] * scene.render.resolution_x
         )
         node_transform.inputs[2].default_value = (
-            background_image.offset[1] * scene.render.resolution_y
+            background_image.offset[1] * scene.render.resolution_x * 9 / 8
         )
         node_transform.inputs[3].default_value = -1 * background_image.rotation
         node_transform.inputs[4].default_value = background_image.scale

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -100,6 +100,15 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
 
             tree.links.new(node_scale.outputs[0], node_conditional.inputs[0])
 
+        node_transform = nodes.new("CompositorNodeTransform")
+
+        node_transform.inputs[1].default_value = (
+            background_image.offset[0] * scene.render.resolution_x
+        )
+        node_transform.inputs[3].default_value = -1 * background_image.rotation
+        node_transform.inputs[4].default_value = background_image.scale
+        tree.links.new(node_conditional.outputs[0], node_transform.inputs[0])
+
         node_translate = nodes.new("CompositorNodeTranslate")
         node_translate.use_relative = True
 
@@ -109,26 +118,17 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
         node_translate.inputs[2].default_value = (
             background_image.offset[1] / background_r
         )
-        tree.links.new(node_conditional.outputs[0], node_translate.inputs[0])
-
-        node_transform = nodes.new("CompositorNodeTransform")
-
-        node_transform.inputs[1].default_value = (
-            background_image.offset[0] * scene.render.resolution_x
-        )
-        node_transform.inputs[3].default_value = -1 * background_image.rotation
-        node_transform.inputs[4].default_value = background_image.scale
-        tree.links.new(node_translate.outputs[0], node_transform.inputs[0])
+        tree.links.new(node_transform.outputs[0], node_translate.inputs[0])
 
         node_alphaOver = nodes.new("CompositorNodeAlphaOver")
         tree.links.new(node_alphaOver.outputs[0], node_right)
 
         if background_image.display_depth == "BACK":
-            tree.links.new(node_transform.outputs[0], node_alphaOver.inputs[1])
+            tree.links.new(node_translate.outputs[0], node_alphaOver.inputs[1])
             tree.links.new(node_left, node_alphaOver.inputs[2])
             node_left = node_alphaOver.outputs[0]
         else:
-            tree.links.new(node_transform.outputs[0], node_alphaOver.inputs[2])
+            tree.links.new(node_translate.outputs[0], node_alphaOver.inputs[2])
             tree.links.new(node_left, node_alphaOver.inputs[1])
             node_right = node_alphaOver.inputs[1]
 


### PR DESCRIPTION
# Issue

Full render 할 때 배경 이미지의 위치가 뷰포트와 다르게 변동하는 이슈입니다.

# 변경사항

해당 기작은 Full render 버튼을 누를 때 compositor에 의해서 구현되도록 개발되어 있습니다. 이 때 compositor에서 배경이미지의 위치를 조정하는 transform 노드의 파라미터가 뷰포트의 배경이미지를 제대로 컨버팅하지 못하고 있었습니다.
또한 다음과 같은 특이사항이 있습니다. (렌더 해상도: resolution, 카메라 배경이미지 위치: offset)

* transform_x 값은 문제 없이 단순하게 컨버팅됨 (`transform_x = resolution_x * offset_x`)
* transform_y 값은 resolution_y 값과는 관계 없이 resolution_x 값에 따라 변동함

따라서 다음과 같은 보정계산식을 적용하였습니다.

```
transform_y = resolution_x * offset_y * 9 / 8
```

이 때의 마지막 보정 상수(`9 / 8`)는 실험적으로 추정한 근사값입니다.