### PR TITLE
패스워드 보여지는 상태에서 첫 번째 로그인에 실패하는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -194,15 +194,12 @@ class LoginTask(AsyncTask):
 
         self.prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
         self.username = self.prop.username
-        self.password = self.prop.password
+        self.password = (
+            self.prop.password_shown if self.prop.show_password else self.prop.password
+        )
 
     def request_login(self):
         prop = self.prop
-
-        if prop.show_password:
-            prop.password = prop.password_shown
-        else:
-            prop.password_shown = prop.password
 
         prop.login_status = "LOADING"
         self.start()


### PR DESCRIPTION
어떤 작업이었는지는 슬랙으로 메시지 드리겠습니다!

패스워드 보여지고 있는 상태에 따라 패스워드 가져오는 속성을 다르게 해야하는 것을, password 만 보고 있어서 생긴 문제였습니다.

AsyncTask 도입 전에도 원래 잘 동작하던 기능인지는 확인해보지는 않았는데, 그 때 뭔가 꼬였을 수도 있겠다는 생각은 듭니다.

"패스워드 보여지게 만든 후, 두 번째 로그인 시도했을 때 성공하게 만든 코드"는 필요 없어 보여서 삭제했습니다.

스듴님은 바쁘시니 @Youdiie @habijung  리뷰 부탁드려요!