### PR TITLE
cameraName이 없을 때 에러

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -92,9 +92,9 @@ class DeleteCameraOperator(bpy.types.Operator):
         return collection and len(collection.objects) > 1
 
     def execute(self, context):
-        currentCameraName = context.scene.ACON_prop.view
-        camera = bpy.data.objects[currentCameraName]
-        bpy.data.objects.remove(camera)
+        if currentCameraName := context.scene.ACON_prop.view:
+            camera = bpy.data.objects[currentCameraName]
+            bpy.data.objects.remove(camera)
 
         return {"FINISHED"}
 

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -93,8 +93,7 @@ class DeleteCameraOperator(bpy.types.Operator):
 
     def execute(self, context):
         if currentCameraName := context.scene.ACON_prop.view:
-            camera = bpy.data.objects[currentCameraName]
-            bpy.data.objects.remove(camera)
+            bpy.data.objects.remove(bpy.data.objects[currentCameraName])
 
         return {"FINISHED"}
 


### PR DESCRIPTION
센트리 오류 중 cameraName = ""인 경우에는 bpy.data.objects[]에서 네이밍으로 찾을 수 없다고 오류가 생깁니다. 실제로 cameraName이 있는지 바다코끼리로 확인하도록 변경했습니다.
(노션 카드 : https://www.notion.so/acon3d/3D-My-Cards-eba53ab450d24d71804448ab0f277459?p=76a2bcd390e248d8a299e62e1c109a3e)
