### PR TITLE
믹스패널 트래킹 부분에서 반복적으로 발생하고 있는 에러에 대한 처리 추가

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -1,7 +1,7 @@
 import threading
 from typing import Optional, Any
 import os
-from uuid import uuid4
+from uuid import uuid4, UUID
 import threading
 
 from mixpanel import Mixpanel, BufferedConsumer
@@ -12,6 +12,7 @@ from ._tracker import Tracker
 
 _user_path = bpy.utils.resource_path("USER")
 _tid_path = os.path.join(_user_path, "abler_tid")
+_tid_length = 36  # UUID str length
 
 
 def _nonblock(runner):
@@ -19,6 +20,40 @@ def _nonblock(runner):
         threading.Thread(target=runner, daemon=True, args=args, kwargs=kwargs).start()
 
     return wrapper
+
+
+def read_tid() -> Optional[str]:
+    if not os.path.exists(_tid_path):
+        return None
+    try:
+        with open(_tid_path, "r") as f:
+            uuid_str = f.read(_tid_length)
+            uuid = UUID(uuid_str)  # possible TypeError if uuid_str is invalid
+            return str(uuid)
+    except:
+        remove_tid()
+        return None
+
+
+def generate_and_write_tid() -> Optional[str]:
+    try:
+        with open(_tid_path, "w") as f:
+            tid = str(uuid4())
+            f.write(tid)
+            return tid
+    except:
+        return None
+
+
+def remove_tid():
+    try:
+        os.remove(_tid_path)
+    except:
+        pass
+
+
+class MixpanelResourceInitializeError(Exception):
+    pass
 
 
 class MixpanelResource:
@@ -37,16 +72,11 @@ class MixpanelResource:
         self.mp = Mixpanel(token, consumer=self._consumer)
 
         # NOTE: 로그아웃 후 다른 이메일로 로그인하는 경우는 고려하지 않음
-        try:
-            if not os.path.exists(_tid_path):
-                with open(_tid_path, "w") as f:
-                    f.write(str(uuid4()))
-            with open(_tid_path, "r") as f:
-                self.tid = f.read(36)
-        except OSError:
-            self.tid = "anonymous"
-
-        self.flush_repeatedly()
+        if tid := read_tid() or generate_and_write_tid():
+            self.tid = tid
+            self.flush_repeatedly()
+        else:
+            raise MixpanelResourceInitializeError()
 
     def flush_repeatedly(self):
         if not self._repeating:
@@ -73,8 +103,12 @@ class MixpanelTracker(Tracker):
         self._mixpanel_token = mixpanel_token
 
     def _ensure_resource(self):
-        if self._r is None:
-            self._r = MixpanelResource(self._mixpanel_token)
+        try:
+            if self._r is None:
+                self._r = MixpanelResource(self._mixpanel_token)
+        except Exception as e:
+            self.turn_off()
+            raise e
 
     @_nonblock
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):


### PR DESCRIPTION
## 문제 1: distinct_id 가 비어있는 문제

기존에는 최초 tid 생성 시에 파일을 쓰자마자 읽었었는데,
이 때 파일이 다 쓰여지기 전에 읽는 경우가 생기는 것으로 추정돼서,
파일 읽기를 먼저 시도하고 없으면 파일 쓰기만 시도함으로써
파일 쓰기 직후에 파일 읽기가 일어나는 일이 없도록 수정했습니다.

혹시나 파일 생성만 되고 쓰기에 실패한 경우,
uuid 포맷이 아닌 다른 포맷이 기록되어 있을 수 있으니
읽기 시점에 유효성 검증 과정을 추가했습니다.
tid 파일에 UUID 형식에 어긋나는 문자열이 들어있는 경우, tid 파일을 삭제하도록 수정했습니다.

## 문제 2 - anonymous 트래킹은 되지 않도록 수정

기존에는 anonymous 를 tid 로 사용했는데, 이렇게 했을 때 다수 사용자의 데이터가 섞일 수 있다는 문제가 있습니다.
이보다는 아예 트래킹이 일시적으로 비활성화되는 것이 맞다고 판단돼서, 그렇게 수정했습니다.

## 문제 3: 5초에 한 번씩 Mixpanel 에 요청을 보낼 때마다 센트리에 에러가 보고됐던 문제

distinct_id 가 비어있어서 이벤트를 전송하면 예외가 발생하는 상태에 빠졌을 때에도,
5초에 한 번씩 Mixpanel 에 flush 하는 과정을 중지하지 않아서 예외가 다수 발생했습니다.

Mixpanel flush 과정 중에서 예외가 발생하면, 더 이상 전송시도를 하지 않도록 처리했습니다.

---

그 밖에, 수정을 하면서 `Mixpanel 에 이벤트 전송을 할 수 없는 상황이 됐을 때, 반드시 Sentry 에 에러 리포팅이 되도록 reraise 를 한다` 는 기준으로 코드를 작성했습니다.