### PR TITLE
로그인 없이 사용하는 문제 해결

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -151,15 +151,23 @@ class Acon3dModalOperator(bpy.types.Operator):
         userInfo = bpy.data.meshes.get("ACON_userInfo")
 
         def char2key(c):
-            result = ctypes.windll.User32.VkKeyScanW(ord(c))
-            shift_state = (result & 0xFF00) >> 8
-            return result & 0xFF
+            # 로그인 modal 창 밖에서 마우스 홀드로 modal 없는 상태에서 키보드로 연타할 때
+            # ord() expected a character, but string of length 0 found 발생
+            # length가 0일 때도 splash 실행
+            if not c:
+                bpy.ops.wm.splash("INVOKE_DEFAULT")
+
+            else:
+                result = ctypes.windll.User32.VkKeyScanW(ord(c))
+                shift_state = (result & 0xFF00) >> 8
+                return result & 0xFF
 
         if userInfo and userInfo.ACON_prop.login_status == "SUCCESS":
             return {"FINISHED"}
 
-        if event.type == "LEFTMOUSE":
+        if event.type in ("LEFTMOUSE", "MIDDLEMOUSE", "RIGHTMOUSE"):
             bpy.ops.wm.splash("INVOKE_DEFAULT")
+
         if event.type in self.pass_key:
             if platform.system() == "Windows":
                 if event.type == "BACK_SPACE":


### PR DESCRIPTION
## 문제
에이블러를 로그인 없이 사용 가능한 문제가 있었습니다.
오류 : `ord() expected a character, but string of length 0 found`

## 수정 사항
- `char2key(c)` 에서 키보드 값이 없을 때 `splash` 창 띄워주기
- 마우스 왼쪽, 중간, 오른쪽 모든 클릭에 대해서 `splash` 창 띄워주기

## 해결 사항
- `splash` 창이 없을 때 키보드를 연타해도 `splash` 창 생성

## 보완할 사항
- [ ] `ctypes.windll.user32.keybd_event()` 없이도 연타 가능한지 추후에 확인
